### PR TITLE
Correcting environments typo

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -13,8 +13,8 @@ module Octopus
   def self.config()
     @config ||= HashWithIndifferentAccess.new(YAML.load(ERB.new(File.open(Octopus.directory() + "/config/shards.yml").read()).result))[Octopus.env()]
 
-    if @config && @config['enviroments']
-      self.enviroments = @config['enviroments']
+    if @config && @config['environments']
+      self.environments = @config['environments']
     end
 
     @config
@@ -33,12 +33,12 @@ module Octopus
     yield self
   end
 
-  def self.enviroments=(enviroments)
-    @enviroments = enviroments.map { |element| element.to_s }
+  def self.environments=(environments)
+    @environments = environments.map { |element| element.to_s }
   end
 
-  def self.enviroments
-    @enviroments || ['production']
+  def self.environments
+    @environments || ['production']
   end
 
   def self.rails3?

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -11,7 +11,7 @@ module Octopus::Model
     end
 
     def using(shard)
-      return self if defined?(::Rails) && !Octopus.enviroments.include?(Rails.env.to_s)
+      return self if defined?(::Rails) && !Octopus.environments.include?(Rails.env.to_s)
       
       clean_table_name()
       hijack_initializer()
@@ -43,7 +43,7 @@ module Octopus::Model
 
     def hijack_connection()
       def self.should_use_normal_connection?
-        (defined?(Rails) && Octopus.config() && !Octopus.enviroments.include?(Rails.env.to_s)) || self.read_inheritable_attribute(:establish_connection)
+        (defined?(Rails) && Octopus.config() && !Octopus.environments.include?(Rails.env.to_s)) || self.read_inheritable_attribute(:establish_connection)
       end
       
       def self.connection_proxy

--- a/spec/config/shards.yml
+++ b/spec/config/shards.yml
@@ -92,7 +92,7 @@ production_fully_replicated:
 octopus_rails:
   replicated: true
   verify_connection: true
-  enviroments:
+  environments:
     - staging
     - production
 

--- a/spec/octopus/migration_spec.rb
+++ b/spec/octopus/migration_spec.rb
@@ -76,7 +76,7 @@ describe Octopus::Migration do
 
   describe "when using replication" do    
     it "should run writes on master when you use replication" do
-      using_enviroment :production_replicated do 
+      using_environment :production_replicated do 
         migrating_to_version 10 do 
           Cat.find_by_name("Replication").should be_nil
         end
@@ -84,7 +84,7 @@ describe Octopus::Migration do
     end
 
     it "should run in all shards, master or another shards" do
-      using_enviroment :production_replicated do 
+      using_environment :production_replicated do 
         migrating_to_version 11 do 
           [:slave4, :slave1, :slave2, :slave3].each do |sym|
             Cat.find_by_name("Slaves").should_not be_nil

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -350,13 +350,13 @@ describe Octopus::Model do
 
   describe "#replicated_model method" do
     it "should be replicated" do
-      using_enviroment :production_replicated do 
+      using_environment :production_replicated do 
         ActiveRecord::Base.connection_proxy.instance_variable_get(:@replicated).should be_true
       end
     end
 
     it "should mark the Cat model as replicated" do
-      using_enviroment :production_replicated do 
+      using_environment :production_replicated do 
         User.read_inheritable_attribute(:replicated).should be_false
         Cat.read_inheritable_attribute(:replicated).should be_true
       end

--- a/spec/octopus/octopus_spec.rb
+++ b/spec/octopus/octopus_spec.rb
@@ -20,19 +20,19 @@ describe Octopus do
   end
   
   describe "#setup method" do    
-    it "should have the default octopus enviroment as production" do
-      Octopus.enviroments.should == ["production"]
+    it "should have the default octopus environment as production" do
+      Octopus.environments.should == ["production"]
     end
     
-    it "should allow the user to configure the octopus enviroments" do
+    it "should allow the user to configure the octopus environments" do
       Octopus.setup do |config|
-        config.enviroments = [:production, :staging]
+        config.environments = [:production, :staging]
       end
       
-      Octopus.enviroments.should == ['production', 'staging']      
+      Octopus.environments.should == ['production', 'staging']      
 
       Octopus.setup do |config|
-        config.enviroments = [:production]
+        config.environments = [:production]
       end
     end
   end

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -37,7 +37,7 @@ describe Octopus::Proxy do
 
     describe "should initialize just the master when you don't have a shards.yml file" do
       before(:each) do
-        set_octopus_env("crazy_enviroment")              
+        set_octopus_env("crazy_environment")              
       end
 
       it "should initialize just the master shard" do
@@ -54,7 +54,7 @@ describe Octopus::Proxy do
     end
   end
 
-  describe "when you have a replicated enviroment" do
+  describe "when you have a replicated environment" do
     before(:each) do
       set_octopus_env("production_replicated")      
     end
@@ -74,23 +74,23 @@ describe Octopus::Proxy do
       set_octopus_env("octopus_rails")
     end
 
-    it "should initialize correctly octopus common variables for the enviroments" do
+    it "should initialize correctly octopus common variables for the environments" do
       Rails.stub!(:env).and_return('staging')
       Octopus.instance_variable_set(:@rails_env, nil)
       Octopus.config()
 
       proxy.instance_variable_get(:@replicated).should be_true
       proxy.instance_variable_get(:@verify_connection).should be_true
-      Octopus.enviroments.should == ["staging", "production"] 
+      Octopus.environments.should == ["staging", "production"] 
     end
 
-    it "should initialize correctly the shards for the staging enviroment" do
+    it "should initialize correctly the shards for the staging environment" do
       Rails.stub!(:env).and_return('staging')
 
       proxy.instance_variable_get(:@shards).keys.to_set.should == Set.new([:slave1, :slave2, :master])
     end
 
-    it "should initialize correctly the shards for the production enviroment" do
+    it "should initialize correctly the shards for the production environment" do
       Rails.stub!(:env).and_return('production')
 
       proxy.instance_variable_get(:@shards).keys.to_set.should == Set.new([:slave3, :slave4, :master])

--- a/spec/octopus/replication_specs.rb
+++ b/spec/octopus/replication_specs.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "when the database is replicated" do
   it "should send all writes/reads queries to master when you have a non replicated model" do
-    using_enviroment :production_replicated do 
+    using_environment :production_replicated do 
       u = User.create!(:name => "Replicated")
       User.count.should == 1
       User.find(u.id).should == u
@@ -10,7 +10,7 @@ describe "when the database is replicated" do
   end
 
   it "should send all writes queries to master" do
-    using_enviroment :production_replicated do 
+    using_environment :production_replicated do 
       Cat.create!(:name => "Slave Cat")    
       Cat.find_by_name("Slave Cat").should be_nil
       Client.create!(:name => "Slave Client")
@@ -19,7 +19,7 @@ describe "when the database is replicated" do
   end
 
   it "should allow to create multiple models on the master" do
-    using_enviroment :production_replicated do 
+    using_environment :production_replicated do 
       Cat.create!([{:name => "Slave Cat 1"}, {:name => "Slave Cat 2"}])  
       Cat.find_by_name("Slave Cat 1").should be_nil
       Cat.find_by_name("Slave Cat 2").should be_nil
@@ -29,14 +29,14 @@ describe "when the database is replicated" do
   it "should allow #using syntax to send queries to master" do
     Cat.create!(:name => "Master Cat")    
     
-    using_enviroment :production_fully_replicated do 
+    using_environment :production_fully_replicated do 
       Cat.using(:master).find_by_name("Master Cat").should_not be_nil
     end
   end
 
   it "should send the count query to a slave" do
     pending()
-    # using_enviroment :production_replicated do 
+    # using_environment :production_replicated do 
     #       Cat.create!(:name => "Slave Cat")    
     #       Cat.count.should == 0
     #     end
@@ -51,7 +51,7 @@ describe "when the database is replicated and the entire application is replicat
   end
 
   it "should send all writes queries to master" do
-    using_enviroment :production_fully_replicated do 
+    using_environment :production_fully_replicated do 
       Cat.create!(:name => "Slave Cat")    
       Cat.find_by_name("Slave Cat").should be_nil
       Client.create!(:name => "Slave Client")
@@ -62,7 +62,7 @@ describe "when the database is replicated and the entire application is replicat
   it "should work with validate_uniquess_of" do
     Keyboard.create!(:name => "thiago")
     
-    using_enviroment :production_fully_replicated do 
+    using_environment :production_fully_replicated do 
       k = Keyboard.new(:name => "thiago")
       k.save.should be_false
       k.errors.should == {:name=>["has already been taken"]}

--- a/spec/octopus/sharded_spec.rb
+++ b/spec/octopus/sharded_spec.rb
@@ -10,7 +10,7 @@ describe "when the database is not entire sharded" do
     pending()
     # User.create!(:name => "Thiago")
     # 
-    # using_enviroment :not_entire_sharded do 
+    # using_environment :not_entire_sharded do 
     #   Octopus.using(:russia) do
     #     User.create!(:name => "Thiago")
     #   end
@@ -22,7 +22,7 @@ describe "when the database is not entire sharded" do
   it "should pick the shard based on current_shard when you have a sharded model" do
     Cat.create!(:name => "Thiago")
 
-    using_enviroment :not_entire_sharded do 
+    using_environment :not_entire_sharded do 
       Octopus.using(:russia) do
         Cat.create!(:name => "Thiago")
       end

--- a/spec/octopus_helper.rb
+++ b/spec/octopus_helper.rb
@@ -19,9 +19,9 @@ def migrating_to_version(version, &block)
   end
 end
 
-def using_enviroment(enviroment, &block)
+def using_environment(environment, &block)
   begin
-    set_octopus_env(enviroment.to_s)
+    set_octopus_env(environment.to_s)
     clean_connection_proxy()
     yield
   ensure


### PR DESCRIPTION
Enviroments should be environments.

It tripped me up and I'm sure it tripped up others.
