### PR TITLE
preserve options hash on reload

### DIFF
--- a/lib/octopus/rails3/persistence.rb
+++ b/lib/octopus/rails3/persistence.rb
@@ -16,9 +16,9 @@ module Octopus
         super
       end
 
-      def reload
+      def reload(options = {})
         reload_connection()
-        super
+        super(options)
       end
 
       def delete


### PR DESCRIPTION
relevant for {:lock => true} option in my case, but probably other relevant situations.
