### PR TITLE
rails 2.3 and after_initialize callback

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -31,7 +31,6 @@ module Octopus::Model
 
     def hijack_initializer()
       attr_accessor :current_shard
-      after_initialize :set_current_shard
       before_save :reload_connection
 
       def set_current_shard
@@ -42,7 +41,9 @@ module Octopus::Model
         end
       end
 
-      if !Octopus.rails3?
+      if Octopus.rails3?
+        after_initialize :set_current_shard
+      else
         def after_initialize
           set_current_shard()
         end


### PR DESCRIPTION
Hi Tiago,

We started to use Octopus in one of our old applications running on 2.3.11. Functionally everything is fine but we're having troubles with requests getting slower over time. So I spent some time digging into code and benchmarking today. The place that causes the issue is the after_initialize callback invoked during record instantiation.
Looking at the code in lib/octopus/model.rb it seems that the callback is defined twice for rails 2. I updated the code to prevent this and it solved our issue.

This code demostrates the issue. Running it shows rapidly growing times.

```
loop do
  Octopus.using(:shard) do
    connection = SalesListing.connection
    record = connection.select_one "SELECT * FROM users LIMIT 1"
    t = Benchmark.ms { 10000.times {
      object = SalesListing.allocate
      object.send(:callback, :after_initialize) # taken from ActiveRecord::Base#instantiate(record)
    } }
    puts "%.3f" % t
  end
end
```
