### PR TITLE
Relax ActiveRecord and ActionPack version check to make it more compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
-gem 'activerecord', '3.0.6'
-gem 'actionpack', '3.0.6'
+gem 'activerecord', '~> 3.0.6'
+gem 'actionpack', '~> 3.0.6'
 
 group :test do
   gem "rake", ">= 0.8.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (= 3.0.6)
-  activerecord (= 3.0.6)
+  actionpack (~> 3.0.6)
+  activerecord (~> 3.0.6)
   jeweler (>= 1.4)
   mysql2
   pg (>= 0.9.0)

--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -171,8 +171,8 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activerecord>, ["= 3.0.6"])
-      s.add_runtime_dependency(%q<actionpack>, ["= 3.0.6"])
+      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0.6"])
+      s.add_runtime_dependency(%q<actionpack>, ["~> 3.0.6"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.0.beta.19"])
       s.add_development_dependency(%q<mysql2>, [">= 0"])
       s.add_development_dependency(%q<pg>, [">= 0.9.0"])
@@ -181,8 +181,8 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<actionpack>, [">= 2.3"])
       s.add_runtime_dependency(%q<activerecord>, [">= 2.3"])
     else
-      s.add_dependency(%q<activerecord>, ["= 3.0.6"])
-      s.add_dependency(%q<actionpack>, ["= 3.0.6"])
+      s.add_dependency(%q<activerecord>, ["~> 3.0.6"])
+      s.add_dependency(%q<actionpack>, ["~> 3.0.6"])
       s.add_dependency(%q<rspec>, [">= 2.0.0.beta.19"])
       s.add_dependency(%q<mysql2>, [">= 0"])
       s.add_dependency(%q<pg>, [">= 0.9.0"])
@@ -192,8 +192,8 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<activerecord>, [">= 2.3"])
     end
   else
-    s.add_dependency(%q<activerecord>, ["= 3.0.6"])
-    s.add_dependency(%q<actionpack>, ["= 3.0.6"])
+    s.add_dependency(%q<activerecord>, ["~> 3.0.6"])
+    s.add_dependency(%q<actionpack>, ["~> 3.0.6"])
     s.add_dependency(%q<rspec>, [">= 2.0.0.beta.19"])
     s.add_dependency(%q<mysql2>, [">= 0"])
     s.add_dependency(%q<pg>, [">= 0.9.0"])


### PR DESCRIPTION
Hi there, I'm using Octopus with Rails 3.0.9 but the current `gemspec` makes it incompatible. I don't think there is a reason to make it so strict so I relaxed it to any patch version under the 3.0 major.

Cheers!
