### PR TITLE
Rails 3.2 support: use 'active_support/core_ext/class/attribute' instead...

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -1,4 +1,8 @@
-require 'active_support/core_ext/class/inheritable_attributes'
+if Gem.loaded_specs['activesupport'].version > Gem::Version.create('3.2.0.pre') # ActiveSupport 3.2
+  require 'active_support/core_ext/class/attribute'
+else # ActiveSupport 3.0, 3.1
+  require 'active_support/core_ext/class/inheritable_attributes'
+end
 require "yaml"
 require "erb"
 


### PR DESCRIPTION
... of 'active_support/core_ext/class/inheritable_attributes' with 3.2
