### PR TITLE
Fix to Rails 2 compatibility

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -1,6 +1,7 @@
-if ActiveSupport::VERSION::MAJOR == 3 && ActiveSupport::VERSION::MINOR > 1 # ActiveSupport 3.2
+require 'active_support/version'
+if ActiveSupport::VERSION::MAJOR == 3 && ActiveSupport::VERSION::MINOR > 1
   require 'active_support/core_ext/class/attribute'
-else # ActiveSupport 3.0, 3.1                      
+else
   require 'active_support/core_ext/class/inheritable_attributes'
 end
 


### PR DESCRIPTION
ActiveSupport doesn't autoload the version in Rails 2.
