### PR TITLE
Relaxing scope proxy to work for methods such as .exists?

### DIFF
--- a/lib/octopus/scope_proxy.rb
+++ b/lib/octopus/scope_proxy.rb
@@ -29,7 +29,7 @@ class Octopus::ScopeProxy
       @klass = @klass.send(method, *args, &block)
     end
 
-    return @klass if @klass.is_a?(ActiveRecord::Base) or @klass.is_a?(Array) or @klass.is_a?(Fixnum) or @klass.nil?
+    return @klass unless @klass.is_a?(ActiveRecord::Relation)
     return self
   end
 

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -186,10 +186,10 @@ describe Octopus::Model do
   end
 
   describe "using a postgresql shard" do
-    it "should update the Arel Engine" do
+    it "should update connection adapter" do
       if ActiveRecord::VERSION::STRING > '2.4.0'
-        User.using(:postgresql_shard).arel_engine.connection.adapter_name.should == "PostgreSQL"
-        User.using(:alone_shard).arel_engine.connection.adapter_name.should == "MySQL"
+        User.using(:postgresql_shard).connection.adapter_name.should == "PostgreSQL"
+        User.using(:alone_shard).connection.adapter_name.should == "MySQL"
       end
     end
 

--- a/spec/octopus/scope_proxy_spec.rb
+++ b/spec/octopus/scope_proxy_spec.rb
@@ -10,6 +10,7 @@ describe Octopus::ScopeProxy do
       User.using(:brazil).where(:name => "Thiago").where(:number => 4).order(:number).all.should == []
       User.using(:brazil).where(:name => "Thiago").using(:canada).where(:number => 2).using(:brazil).order(:number).all.should == [@user3]
       User.using(:brazil).where(:name => "Thiago").using(:canada).where(:number => 4).using(:brazil).order(:number).all.should == []
+      User.using(:brazil).where(:name => "Ghost Thiago").exists?.should be_false
     end
   end
 


### PR DESCRIPTION
Currently, `Octopus::ScopeProxy` is very explicit when determining whether to return the result or the proxy itself. Because of being explicit and trying to determine all the possibilities that could be result of the method call, there is room for potential edge cases to sneak in.

One such edge case that currently isn't caught is `.exists?` as shown in the additional spec example. Calling `.exists?` will return true or false, a value that doesn't pass any of the conditions on https://github.com/tchandy/octopus/blob/8558c52430320fb25e146d0ea744084b84f0801a/lib/octopus/scope_proxy.rb#L32

Because of this, it will always return the ScopeProxy instead of true or false. Instead of adding true or false to the possible return values in that long list of conditionals, I opted for the reverse and return everything unless it is an AR relation.

Anyone have any thoughts on a this approach? Should I instead add true or false to the current list of conditions and hope that no other edge cases come up?
