### PR TITLE
update_attributes in Rails3 only uses 1 parameter

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -60,6 +60,10 @@ module Octopus
     ActiveRecord::VERSION::MAJOR == 3
   end
 
+  def self.rails30?
+    ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR == 0
+  end
+
   def self.rails31?
     ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR >= 1
   end
@@ -98,14 +102,18 @@ if Octopus.rails3?
   require "octopus/rails3/arel"
   require "octopus/rails3/log_subscriber"
   require "octopus/rails3/abstract_adapter"
+  require "octopus/rails3/persistence" unless Octopus.rails30?
 else
   require "octopus/rails2/association"
   require "octopus/rails2/persistence"
 end
 
+if Octopus.rails30?
+  require "octopus/rails3.0/persistence"
+end
+
 if Octopus.rails31?
   require "octopus/rails3.1/singular_association"
-  require "octopus/rails3.1/persistence"
 end
 
 require "octopus/proxy"

--- a/lib/octopus/rails3.0/persistence.rb
+++ b/lib/octopus/rails3.0/persistence.rb
@@ -1,17 +1,17 @@
 module Octopus
-  module Rails31
+  module Rails30
     module Persistence
       def update_attribute(name, value)
         reload_connection()
         super
       end
 
-      def update_attributes(attributes, options = {})
+      def update_attributes(attributes)
         reload_connection()
         super
       end
 
-      def update_attributes!(attributes, options = {})
+      def update_attributes!(attributes)
         reload_connection()
         super
       end
@@ -34,4 +34,4 @@ module Octopus
   end
 end
 
-ActiveRecord::Base.send(:include, Octopus::Rails31::Persistence)
+ActiveRecord::Base.send(:include, Octopus::Rails30::Persistence)

--- a/lib/octopus/rails3/persistence.rb
+++ b/lib/octopus/rails3/persistence.rb
@@ -6,12 +6,12 @@ module Octopus
         super
       end
 
-      def update_attributes(attributes)
+      def update_attributes(attributes, options = {})
         reload_connection()
         super
       end
 
-      def update_attributes!(attributes)
+      def update_attributes!(attributes, options = {})
         reload_connection()
         super
       end


### PR DESCRIPTION
Rails 3.1 and above support the options hash.  I'm still working on getting the tests working on my system (need to setup pg), but the changes are pretty straight forward and I've verified the code works for 3.0.10.
