### PR TITLE
Support parsing a protocol string in shards.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace :db do
 
     # Postgres
     %x( createdb -E UTF8 -U #{postgres_user} octopus_shard_1 )
+    %x( createdb -E UTF8 -U #{postgres_user} octopus_shard_2 )
   end
 
   desc 'Drop the tests databases'
@@ -33,6 +34,7 @@ namespace :db do
     %x( echo "#{sql}" | mysql -u "#{mysql_user}" )
 
     %x( dropdb -U #{postgres_user} octopus_shard_1 )
+    %x( dropdb -U #{postgres_user} octopus_shard_2 )
     %x( rm -f /tmp/database.sqlite3 )
   end
 
@@ -43,7 +45,7 @@ namespace :db do
     require "octopus"
     require "support/database_connection"
 
-    [:master, :brazil, :canada, :russia, :alone_shard, :postgresql_shard, :sqlite_shard].each do |shard_symbol|
+    [:master, :brazil, :canada, :russia, :alone_shard, :postgresql_shard, :sqlite_shard, :protocol_shard].each do |shard_symbol|
       # Rails 3.1 needs to do some introspection around the base class, which requires
       # the model be a descendent of ActiveRecord::Base.
       class BlankModel < ActiveRecord::Base; end;

--- a/spec/config/shards.yml
+++ b/spec/config/shards.yml
@@ -42,6 +42,7 @@ octopus:
         database: octopus_shard_4
         <<: *mysql
 
+    protocol_shard: postgres://<%= ENV['POSTGRES_USER'] || 'postgres' %>@localhost:5432/octopus_shard_2
 
 production_raise_error:
   shards:

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -8,7 +8,7 @@ describe Octopus::Proxy do
       # FIXME: Don't test implementation details
       proxy.instance_variable_get(:@shards).keys.to_set.should == [
         "canada", "brazil", "master", "sqlite_shard", "russia", "alone_shard",
-        "aug2009", "postgresql_shard", "aug2010", "aug2011"
+        "aug2009", "postgresql_shard", "aug2010", "aug2011", "protocol_shard"
       ].to_set
 
       proxy.has_group?("country_shards").should be_true
@@ -58,7 +58,7 @@ describe Octopus::Proxy do
       it 'should not fail with missing adapter second time round' do
         proxy.current_shard = :modify_config_read
         proxy.connection_pool.checkout
-        
+
         lambda { Octopus::Proxy.new(Octopus.config()) }.should_not raise_error("Please install the  adapter: `gem install activerecord--adapter` (cannot load such file -- active_record/connection_adapters/_adapter)")
       end
     end


### PR DESCRIPTION
This patch allows octopus to support full database urls in `shards.yml` instead of having to spell out all the parts, like you can in a rails `database.yml`. This will be especially useful for us on heroku, where I already have the database url handy and I can just ERB it in there.

I didn't add support for strings in shard groups as we haven't had a need for it yet. The three examples that are failing were failing before this patch, not sure what's up there.

Thanks for the great work!
