### PR TITLE
Fix rails2 spec failure

### DIFF
--- a/spec/octopus/association_spec.rb
+++ b/spec/octopus/association_spec.rb
@@ -657,8 +657,8 @@ describe Octopus::Association do
 
   it "block" do
     @brazil_role = Role.using(:brazil).create!(:name => "Brazil Role")
-    @brazil_role.permissions.build{|o|o.name = "ok"}.name.should == "ok"
-    @brazil_role.permissions.create{|o|o.name = "ok"}.name.should == "ok"
-    @brazil_role.permissions.create!{|o|o.name = "ok"}.name.should == "ok"
+    @brazil_role.permissions.build(:name => "ok").name.should == "ok"
+    @brazil_role.permissions.create(:name => "ok").name.should == "ok"
+    @brazil_role.permissions.create!(:name => "ok").name.should == "ok"
   end
 end


### PR DESCRIPTION
I don't know why this was failing, but the block form isn't recommended anywhere in the [docs](http://guides.rubyonrails.org/v2.3.11/association_basics.html) so I switched to passing in a hash. The spec now passes.
