### PR TITLE
Only run any? specs on rails3

### DIFF
--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -261,14 +261,26 @@ describe Octopus::Model do
     describe "any?" do
       before { User.using(:brazil).create!(:name => "User1") }
 
-      it "works when true" do
-        scope = User.using(:brazil).where(:name => "User1")
-        scope.any?.should be_true
-      end
+      if !Octopus.rails3?
+        it "works when true" do
+          scope = User.using(:brazil).scoped(:conditions => {:name => "User1"})
+          scope.any?.should be_true
+        end
 
-      it "works when false" do
-        scope = User.using(:brazil).where(:name => "User2")
-        scope.any?.should be_false
+        it "works when false" do
+          scope = User.using(:brazil).scoped(:conditions => {:name => "User2"})
+          scope.any?.should be_false
+        end
+      else
+        it "works when true" do
+          scope = User.using(:brazil).where(:name => "User1")
+          scope.any?.should be_true
+        end
+
+        it "works when false" do
+          scope = User.using(:brazil).where(:name => "User2")
+          scope.any?.should be_false
+        end
       end
     end
 


### PR DESCRIPTION
Scopes aren't supported on Rails 2.3 and recent specs checking `any?` support broke the specs for that version of Rails.
