### PR TITLE
Properly check equality between sharded AR objects

### DIFF
--- a/lib/octopus/scope_proxy.rb
+++ b/lib/octopus/scope_proxy.rb
@@ -37,8 +37,10 @@ class Octopus::ScopeProxy
     result
   end
 
-  def ==(other)
-    @shard == other.shard
-    @klass == other.klass
+  # Delegates to method_missing (instead of @klass) so that User.using(:blah).where(:name => "Mike")
+  # gets run in the correct shard context when #== is evaluated.
+  def ==(*args)
+    method_missing(:==, *args)
   end
+  alias :eql? :==
 end


### PR DESCRIPTION
Modifies ActiveRecord::Base#== to check that #current_shard is equal (in addition to current #== functionality). Delegates ScopeProxy#== to @klass.
