### PR TITLE
Deprecates .octopus_* methods on AR::Base

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -127,16 +127,29 @@ Occasionally, an application might lose a connection to a database; when this ha
 This will tell Octopus to verify the connection before sending the query.
 
 ## Mixing Octopus with the Rails multiple database model
-If you want to set a custom connection to a specific model, use this syntax:
+If you want to set a custom connection to a specific model, use the normal syntax `establish_connection` syntax:
 
     #This class sets its own connection
-    # establish_connection will not work, use octopus_establish_connection instead.
     class CustomConnection < ActiveRecord::Base
-      octopus_establish_connection(:adapter => "mysql", :database => "octopus_shard2")
+      establish_connection(:adapter => "mysql", :database => "octopus_shard2")
     end
 
 ## Set table names
-If you want to use specific table names, please visit: <a href="https://github.com/tchandy/octopus/wiki/Table-names"> this link</a>
+If you want to use specific table names, use the correct syntax for your version of Rails.
+
+### Rails <= 3.1
+
+    class Bacon < ActiveRecord::Base
+      set_table_name("yummy")
+    end
+
+### Rails >= 3.2
+
+    class Bacon < ActiveRecord::Base
+      self.table_name = "yummy"
+    end
+
+Unfortunately the `self.table_name=` syntax isn't supported on versions of Rails <= 3.1.
 
 ## Contributing with Octopus
 Contributors are welcome! To run the test suite, you need mysql, postgresql and sqlite3 installed. This is what you need to setup your Octopus development environment:

--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'activerecord', '>= 2.3.0'
+  s.add_dependency 'activesupport', '>= 2.3.0'
   s.add_development_dependency 'rake', '>= 0.8.7'
   s.add_development_dependency 'appraisal', '>= 0.3.8'
   s.add_development_dependency 'rspec', '>= 2.0.0'

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -217,7 +217,7 @@ describe Octopus::Model do
   end
 
   describe "AR basic methods" do
-    it "octopus_establish_connection" do
+    it "establish_connection" do
       CustomConnection.connection.current_database.should == "octopus_shard_2"
     end
 
@@ -353,6 +353,14 @@ describe Octopus::Model do
   describe "when using set_table_name" do
     it 'should work correctly' do
       Bacon.using(:brazil).create!(:name => "YUMMMYYYY")
+    end
+  end
+
+  if Octopus.rails32?
+    describe "when using table_name=" do
+      it 'should work correctly' do
+        Ham.using(:brazil).create!(:name => "YUMMMYYYY")
+      end
     end
   end
 

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -25,7 +25,7 @@ end
 
 #This class sets its own connection
 class CustomConnection < ActiveRecord::Base
-  octopus_establish_connection(:adapter => "mysql", :database => "octopus_shard_2", :username => "root", :password => "")
+  establish_connection(:adapter => "mysql", :database => "octopus_shard_2", :username => "root", :password => "")
 end
 
 #This items belongs to a client
@@ -77,5 +77,11 @@ end
 
 
 class Bacon < ActiveRecord::Base
-  octopus_set_table_name "yummy"
+  set_table_name "yummy"
+end
+
+if Octopus.rails32?
+  class Ham < ActiveRecord::Base
+    self.table_name = "yummy"
+  end
 end


### PR DESCRIPTION
Overloads `.establish_connection`, `.set_table_name` and `.table_name=` instead.
