### PR TITLE
db:create:all task doesn't create missing databases

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -154,10 +154,7 @@ module Octopus::Model
     end
 
     def establish_connection_with_octopus(spec = nil)
-      # Checking for self != ActiveRecord::Base is probably unnecessary in real-world usage,
-      # but the test suite uses establish_connection instead of a database.yml to set the
-      # master database.
-      self.custom_octopus_connection = true if spec && self != ActiveRecord::Base
+      self.custom_octopus_connection = true if spec
       establish_connection_without_octopus(spec)
     end
 

--- a/spec/support/database_connection.rb
+++ b/spec/support/database_connection.rb
@@ -1,1 +1,2 @@
 ActiveRecord::Base.establish_connection(:adapter => "mysql", :database => "octopus_shard_1", :username => "root", :password => "")
+ActiveRecord::Base.custom_octopus_connection = false


### PR DESCRIPTION
The db:create:all task attempts to connect to each database and creates it if the database throws an error: https://github.com/rails/rails/blob/v3.2.8/activerecord/lib/active_record/railties/databases.rake#L67-L68

Because AR::Base.establish_connection doesn't work with octopus, AR::Base.connection returns the current shard (which may already exist) rather than the requested database connection. The task then incorrectly reports that databases exist even though they do not.
