### PR TITLE
Checking @block causes queries never to get sent to slaves.

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -205,7 +205,7 @@ class Octopus::Proxy
   end
 
   def should_send_queries_to_replicated_databases?(method)
-    @replicated && method.to_s =~ /select/ && !@block
+    @replicated && method.to_s =~ /select/ #&& !@block
   end
 
   def send_queries_to_selected_slave(method, *args, &block)


### PR DESCRIPTION
When using octopus for replication in ruby 1.9.3/rails 3.2.9, it seemed like read queries were never actually getting sent to slaves.  Instead, all queries were using the default/master database connection.

I think I tracked it down to `Octopus::Proxy#should_send_queries_to_replicated_databases?` and the check that `@block` is false.

I can't say I understand exactly why the check for `!@block` is there in the first place, so I might be breaking something here... but it seems when ensuring that `@block` is false, queries never end up getting sent to slaves.  I believe it's because this seems to _always_ get called from a block in `/lib/octopus/scope_proxy.rb`, lines 28-30.
