### PR TITLE
Fix race condition that happens with zero shards

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -19,7 +19,7 @@ module Octopus
       file_name = Octopus.directory() + "/config/shards.yml"
 
       if File.exists?(file_name)
-        config ||= HashWithIndifferentAccess.new(YAML.load(ERB.new(File.open(file_name).read()).result))[Octopus.env()]
+        config ||= HashWithIndifferentAccess.new(YAML.load(ERB.new(File.read(file_name)).result))[Octopus.env()]
       else
         config ||= HashWithIndifferentAccess.new
       end


### PR DESCRIPTION
When the shards file contains no environments (typical in development environments I suppose), a race condition arises when reading the shards file:

Assuming the shards file is exactly

```
octopus:
```
- `Octopus.config` gets called for each query ;
- Because the shards file is "empty", `@config` doesn't get cached ;
- `File.open` thus gets called for each SQL query ;
- the file handle stays open until the GC kicks in ;
- if you're unlucky (running lots of queries without using much memory), you'll hit the limit on number open files before the GC cleans up unused handles.

On some systems this might just raise an `ENFILE`-based exception; on Darwin 11 with REE, this causes read(2) to (actively) wait forever, throwing your Ruby process into 100% CPU usage.

Replacing `File.open(...).read()` with `File.read(...)` fixes the issue as it closes the file handle straight away.
