### PR TITLE
Update lib/octopus/version.rb

### DIFF
--- a/lib/octopus/version.rb
+++ b/lib/octopus/version.rb
@@ -1,3 +1,3 @@
 module Octopus
-  VERSION = '0.5.0-beta'
+  VERSION = '0.5.0beta'
 end


### PR DESCRIPTION
$ cat Gemfile
gem 'ar-octopus', :require => 'octopus', :git => 'https://github.com/tchandy/octopus.git'

$ bundle update

> Unfortunately, a fatal error has occurred. Please see the Bundler 
> troubleshooting documentation at http://bit.ly/bundler-issues. Thanks! 
> /usr/local/rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:187:in `initialize': Malformed version number string 0.5.0-beta (ArgumentError)
>   from /usr/local/rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in`new'
>   from /usr/local/rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in `create'
>   from /usr/local/rvm/rubies/ruby-1.9.3-p286/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:2129:in`version='
>   from /usr/local/rvm/gems/ruby-1.9.3-p286/bundler/gems/octopus-83d47905fb46/ar-octopus.gemspec:7:in `block in <main>'
