### PR TITLE
establish_connection should default to ENV['DATABASE_URL']

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -153,7 +153,7 @@ module Octopus::Model
       end
     end
 
-    def establish_connection_with_octopus(spec = nil)
+    def establish_connection_with_octopus(spec = ENV['DATABASE_URL'])
       self.custom_octopus_connection = true if spec
       establish_connection_without_octopus(spec)
     end
@@ -163,7 +163,7 @@ module Octopus::Model
       set_table_name_without_octopus(value)
     end
 
-    def octopus_establish_connection(spec = nil)
+    def octopus_establish_connection(spec = ENV['DATABASE_URL'])
       ActiveSupport::Deprecation.warn "Calling `octopus_establish_connection` is deprecated and will be removed in Octopus 1.0.", caller
       establish_connection(spec)
     end


### PR DESCRIPTION
As of Rails 3.2.4, establish_connection takes `ENV['DATABASE_URL']` as the default param, https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb#L128

octopus currently sets this to `nil`, which causes any app that uses `DATABASE_URL` to break with the following exception.

```
/home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb:49:in `resolve_hash_conne
ction': database configuration does not specify adapter (ActiveRecord::AdapterNotSpecified)
        from /home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb:42:in `resol
ve_string_connection'
        from /home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb:25:in `spec'
        from /home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb:135:in `esta
blish_connection'
        from /tmp/deep-sword-5709/vendor/bundle/ruby/1.9.1/bundler/gems/octopus-8ed812836f13/lib/octopus/model.rb:163:in `establish_connection_with_oct
opus'
        from /home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/railtie.rb:82:in `block (2 levels) in <class:Railtie>'
        from /home/hone/Projects/heroku_work/rails/activesupport/lib/active_support/lazy_load_hooks.rb:36:in `instance_eval'
        from /home/hone/Projects/heroku_work/rails/activesupport/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
        from /home/hone/Projects/heroku_work/rails/activesupport/lib/active_support/lazy_load_hooks.rb:26:in `block in on_load'
        from /home/hone/Projects/heroku_work/rails/activesupport/lib/active_support/lazy_load_hooks.rb:25:in `each'
        from /home/hone/Projects/heroku_work/rails/activesupport/lib/active_support/lazy_load_hooks.rb:25:in `on_load'
        from /home/hone/Projects/heroku_work/rails/activerecord/lib/active_record/railtie.rb:74:in `block in <class:Railtie>'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/initializable.rb:30:in `instance_exec'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/initializable.rb:30:in `run'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/initializable.rb:54:in `each'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/initializable.rb:54:in `run_initializers'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/application.rb:136:in `initialize!'
        from /home/hone/Projects/heroku_work/rails/railties/lib/rails/railtie/configurable.rb:30:in `method_missing'
        from /tmp/deep-sword-5709/config/environment.rb:5:in `<top (required)>'
```

I would like to update the default value to be `ENV['DATABASE_URL']`.
