### PR TITLE
Fix overriding of ActiveRecord::Base.set_table_name 

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -158,9 +158,9 @@ module Octopus::Model
       establish_connection_without_octopus(spec)
     end
 
-    def set_table_name_with_octopus(value = nil)
+    def set_table_name_with_octopus(value = nil, &block)
       self.custom_octopus_table_name = true
-      set_table_name_without_octopus(value)
+      set_table_name_without_octopus(value, &block)
     end
 
     def octopus_establish_connection(spec = ENV['DATABASE_URL'])

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -407,6 +407,10 @@ describe Octopus::Model do
     it 'should work correctly' do
       Bacon.using(:brazil).create!(:name => "YUMMMYYYY")
     end
+
+    it 'should work correctly with a block' do
+      Cheese.using(:brazil).create!(:name => "YUMMMYYYY")
+    end
   end
 
   if Octopus.rails32?

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -80,6 +80,10 @@ class Bacon < ActiveRecord::Base
   set_table_name "yummy"
 end
 
+class Cheese < ActiveRecord::Base
+  set_table_name { "yummy" }
+end
+
 if Octopus.rails32?
   class Ham < ActiveRecord::Base
     self.table_name = "yummy"


### PR DESCRIPTION
The current Octopus version of `set_table_name` doesn't properly pass a `&block` to the original method.
