### PR TITLE
ConnectionSpecification::Resolver not available in < 3.2

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -31,14 +31,14 @@ class Octopus::Proxy
     shards_config ||= []
 
     shards_config.each do |key, value|
-      if value.is_a?(String)
+      if value.is_a?(String) && Octopus.rails32?
         value = resolve_string_connection(value)
         initialize_adapter(value['adapter'])
         @shards[key.to_sym] = connection_pool_for(value, "#{value['adapter']}_connection")
-      elsif value.has_key?("adapter")
+      elsif value.is_a?(Hash) && value.has_key?("adapter")
         initialize_adapter(value['adapter'])
         @shards[key.to_sym] = connection_pool_for(value, "#{value['adapter']}_connection")
-      else
+      elsif value.is_a?(Hash)
         @groups[key.to_s] = []
 
         value.each do |k, v|

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -6,10 +6,10 @@ describe Octopus::Proxy do
   describe "creating a new instance" do
     it "should initialize all shards and groups" do
       # FIXME: Don't test implementation details
-      proxy.instance_variable_get(:@shards).keys.to_set.should == [
-        "canada", "brazil", "master", "sqlite_shard", "russia", "alone_shard",
-        "aug2009", "postgresql_shard", "aug2010", "aug2011", "protocol_shard"
-      ].to_set
+      proxy.instance_variable_get(:@shards).should include("canada", "brazil", "master", "sqlite_shard", "russia", "alone_shard",
+                                                           "aug2009", "postgresql_shard", "aug2010", "aug2011")
+
+      proxy.instance_variable_get(:@shards).should include("protocol_shard") if Octopus.rails32?
 
       proxy.has_group?("country_shards").should be_true
       proxy.shards_for_group("country_shards").should include(:canada, :brazil, :russia)


### PR DESCRIPTION
#117 breaks the specs in versions < 3.2 since the Resolver class isn't available. My ideal solution would be to stop supporting versions < 3.2, but in the meantime we should probably revert the commit.
