### PR TITLE
Expose rake tasks to Rails and update README for 2.3 support

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -59,6 +59,10 @@ master database to each of the shards:
 Once the task completes migrations will operate normally and schema information will be stored in each shard database
 going forward.
 
+In order to run this task in Rails 2.3, you'll need to tell Rails to load Octopus' rake tasks by adding this to your `Rakefile`:
+
+    Dir["#{Gem.searcher.find('ar-octopus').full_gem_path}/lib/tasks/**/*.rake"].each { |ext| load ext }
+
 ## How to use Octopus?
 
 First, you need to create a config file, shards.yml, inside your config/ directory. to see the syntax and how this file should look, please checkout <a href="http://wiki.github.com/tchandy/octopus/config-file">this page on wiki</a>.

--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -121,6 +121,7 @@ if Octopus.rails3?
   require "octopus/rails3/arel"
   require "octopus/rails3/log_subscriber"
   require "octopus/rails3/abstract_adapter"
+  require "octopus/railtie"
 end
 
 if Octopus.rails30?

--- a/lib/octopus/railtie.rb
+++ b/lib/octopus/railtie.rb
@@ -1,0 +1,9 @@
+require "rails/railtie"
+
+module Octopus
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      Dir[File.join(File.dirname(__FILE__), "../tasks/*.rake")].each { |ext| load ext }
+    end
+  end
+end


### PR DESCRIPTION
The rake tasks weren't being properly exposed to Rails. This commit fixes that.
