### PR TITLE
Fix specs when railties isn't available

### DIFF
--- a/lib/octopus/railtie.rb
+++ b/lib/octopus/railtie.rb
@@ -1,9 +1,13 @@
-require "rails/railtie"
+begin
+  require "rails/railtie"
 
-module Octopus
-  class Railtie < Rails::Railtie
-    rake_tasks do
-      Dir[File.join(File.dirname(__FILE__), "../tasks/*.rake")].each { |ext| load ext }
+  module Octopus
+    class Railtie < Rails::Railtie
+      rake_tasks do
+        Dir[File.join(File.dirname(__FILE__), "../tasks/*.rake")].each { |ext| load ext }
+      end
     end
   end
+rescue LoadError
+  # nop
 end


### PR DESCRIPTION
When we drop 2.3 support we can just depend on railties, but for the moment we just need to recover when we don't have it.
