### PR TITLE
Respect establish_connection in superclass in all subclasses

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -123,6 +123,8 @@ module Octopus::Model
     include SharedMethods
 
     def self.extended(base)
+      base.class_attribute(:custom_octopus_connection, :instance_reader => false, :instance_writer => false)
+      base.class_attribute(:custom_octopus_table_name, :instance_reader => false, :instance_writer => false)
       base.class_attribute(:replicated)
       base.class_attribute(:sharded)
       base.hijack_methods
@@ -138,9 +140,6 @@ module Octopus::Model
 
     def hijack_methods
       class << self
-        attr_accessor :custom_octopus_connection
-        attr_accessor :custom_octopus_table_name
-
         alias_method_chain(:establish_connection, :octopus)
         alias_method_chain(:set_table_name, :octopus)
 

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -258,8 +258,14 @@ describe Octopus::Model do
   end
 
   describe "AR basic methods" do
-    it "establish_connection" do
-      CustomConnection.connection.current_database.should == "octopus_shard_2"
+    describe "establish_connection" do
+      it "establish_connection" do
+        CustomConnection.connection.current_database.should == "octopus_shard_2"
+      end
+
+      it "establishes connection for subclasses" do
+        SubclassConnection.connection.current_database.should == "octopus_shard_2"
+      end
     end
 
     it "increment" do

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -28,6 +28,8 @@ class CustomConnection < ActiveRecord::Base
   establish_connection(:adapter => "mysql", :database => "octopus_shard_2", :username => "root", :password => "")
 end
 
+class SubclassConnection < CustomConnection; end
+
 #This items belongs to a client
 class Item < ActiveRecord::Base
   belongs_to :client


### PR DESCRIPTION
If .establish_connection is run on a class, any subclasses will use the specified connection instead of running through octopus.
