### PR TITLE
README update - pull from master instead of rubygems.

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -41,7 +41,9 @@ Add this line to Gemfile:
 
     gem 'ar-octopus', :require => 'octopus'
 
-Runs a bundle install:
+**Note**: The `ar-octopus` gem build is out of date. Until a new build is created, we recommend using the gem from this repo by placing `gem "ar-octopus", github: "tchandy/octopus", require: "octopus"` in your Gemfile instead of the above line. Alternatively you can [create your own fork](https://github.com/tchandy/octopus/fork_select) (for added stability against changes to master) and reference that fork from your Gemfile: `gem "ar-octopus", github: "<fork owner>/octopus", require: "octopus"`.
+
+Run a bundle install:
 
     bundle install
 


### PR DESCRIPTION
It sounds like multiple users (myself included) have wasted time by following the instructions to pull the lastest gem (0.4.0) from rubygems only to see bundler errors and then research to see that using master is expected. Hope this helps clear that up until a new build is created.

Thanks!
