### PR TITLE
release all shard connections when ActiveRecord::Base.clear_active_connections! is called

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -72,7 +72,12 @@ module Octopus::Model
         end
       end
 
+      def self.clear_active_connections_with_octopus!
+        connection_proxy.instance_variable_get('@shards').each_value {|pool| pool.release_connection } 
+      end
+
       class << self
+        alias_method_chain :clear_active_connections!, :octopus
         alias_method_chain :connection, :octopus
         alias_method_chain :connection_pool, :octopus
       end


### PR DESCRIPTION
While using octopus with jruby we found that if our number of threads exceeded the database pool connection size then requests would hang and we would get the following error:

ActiveRecord::ConnectionTimeoutError (could not obtain a database connection within 5 seconds (waited 5.0 seconds). The max pool size is currently 5; consider increasing it.)

Our controller method only had a single line in it.

``` ruby
@petition = Petition.using(:slave0).first
```

Further investigation found that the ActiveRecord::Base.clear_active_connections! method which is called at the end of the request cycle was only releasing the master connection and shard connection.  It appears this is because octopus does not hijack the clear_active_connections! method, so the standard ActiveRecord implementation is used, which is unaware of the shard connections.

Our attempted fix is to just hijack this method and make sure release_connection is called on every shard.  Before writing up a test case for this we just wanted to confirm our suspicions about the cause of this error, and that our fix approach is on the right track.  
