### PR TITLE
Dump query cache in a sharding-aware fashion.

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -228,11 +228,19 @@ class Octopus::Proxy
   end
 
   def enable_query_cache!
-    @shards.each { |k, v| safe_connection(v).enable_query_cache! }
+    @shards.each do |k, v|
+      c = safe_connection(v)
+      c.clear_query_cache_without_octopus
+      c.enable_query_cache!
+    end
   end
 
   def disable_query_cache!
     @shards.each { |k, v| safe_connection(v).disable_query_cache! }
+  end
+
+  def clear_all_query_caches!
+    @shards.each { |k, v| safe_connection(v).clear_query_cache_without_octopus }
   end
 
   protected

--- a/lib/octopus/rails3/abstract_adapter.rb
+++ b/lib/octopus/rails3/abstract_adapter.rb
@@ -21,6 +21,7 @@ module Octopus
 
       def self.included(base)
         base.alias_method_chain :initialize, :octopus_shard
+        base.alias_method_chain :clear_query_cache, :octopus
       end
 
       def octopus_shard
@@ -30,6 +31,16 @@ module Octopus
       def initialize_with_octopus_shard(*args)
         initialize_without_octopus_shard(*args)
         @instrumenter = InstrumenterDecorator.new(self, @instrumenter)
+      end
+
+      # Intercept calls to clear_query_cache and make sure that all
+      # query caches on all shards are invalidated, just to be safe.
+      def clear_query_cache_with_octopus
+        if Octopus.enabled?
+          ActiveRecord::Base.connection_proxy.clear_all_query_caches!
+        else
+          clear_query_cache_without_octopus
+        end
       end
 
     end

--- a/spec/octopus/replication_spec.rb
+++ b/spec/octopus/replication_spec.rb
@@ -31,14 +31,14 @@ describe "when the database is replicated" do
 
     it "should do the queries with cache" do
       OctopusHelper.using_environment :replicated_with_one_slave  do
-        cat1 = Cat.using(:master).create!(:name => "Slave Cat 1")
-        cat2 = Cat.using(:master).create!(:name => "Slave Cat 1")
+        cat1 = Cat.using(:master).create!(:name => "Master Cat 1")
+        cat2 = Cat.using(:master).create!(:name => "Master Cat 2")
         Cat.using(:master).find(cat1.id).should eq(cat1)
         Cat.using(:master).find(cat1.id).should eq(cat1)
         Cat.using(:master).find(cat1.id).should eq(cat1)
 
-        cat3 = Cat.using(:slave1).create!(:name => "Slave Cat 1")
-        cat4 = Cat.using(:slave1).create!(:name => "Slave Cat 1")
+        cat3 = Cat.using(:slave1).create!(:name => "Slave Cat 3")
+        cat4 = Cat.using(:slave1).create!(:name => "Slave Cat 4")
         Cat.find(cat3.id).id.should eq(cat3.id)
         Cat.find(cat3.id).id.should eq(cat3.id)
         Cat.find(cat3.id).id.should eq(cat3.id)


### PR DESCRIPTION
This should solve https://github.com/tchandy/octopus/issues/81

This commit adds two features to query cache invalidation which
are not necessary in a single-database-connection world:

(1) It empties the cache each time enable_query_cache! is called
(typically once per request cycle), since it is not clear whether
the shard that was used for query caching in the previous request
will have a cache image that is consistent with the shard that is
being used for the current request.

(2) When a shard-invalidating event (currently defined as one of
:insert, :update, :delete) occurs, _all_ shards will have their
query caches dumped rather than just the shard on which the update
occurred. This will provide consistent data images during the
lifetime of a single request, e.g. if the application tends to
request certain objects from a master database in some cases and
from its slave copy in other cases (for example: a master database
that is used for looking up users and slave database on which the
user and all of their related data is stored)
