### PR TITLE
connection is lost when if process forked.

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -234,6 +234,10 @@ class Octopus::Proxy
     @shards.each { |k, v| safe_connection(v).clear_query_cache_without_octopus }
   end
 
+  def disconnect!
+    @shards.each { |k, v| v.disconnect! }
+  end
+
   protected
 
   def connection_pool_for(adapter, config)

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -263,4 +263,15 @@ describe Octopus::Proxy do
       end
     end
   end
+
+  describe "forked instance" do
+    context "disconnect before fork" do
+      it "can use connection" do
+        proxy.disconnect!
+        fork do
+          expect( proxy.select_connection.quote_string("'quote") ).to eq("\\'quote")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi.
I found a bug that connection is missing when a proxy connection disconnect and process fork.
The problem affected when you using pre fork model rack application server like Phusion Passenger or unicorn etc...
I fixed it.

Thanks
