### PR TITLE
Improve README: unnecessary `require` in Gemfile

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -27,7 +27,7 @@ When using replication, all writes queries will be sent to master, and read quer
 
 Add this line to Gemfile:
 
-    gem 'ar-octopus', :require => 'octopus'
+    gem 'ar-octopus'
 
 Currently, Octopus doesn't support Rails 2. If you need support for rails 2, please use the version 0.5.0.
 


### PR DESCRIPTION
Because there is [lib/ar-octopus.rb](https://github.com/tchandy/octopus/blob/master/lib/ar-octopus.rb) and it requires octopus,we don't have to write `require: "octopus"` by the hand. I just checked it by the following steps:

```
$ rails new example --skip-bundle
$ cd example
$ echo 'gem "ar-octopus", "0.8.0"' >> Gemfile
$ bundle
$ rails runner "puts Octopus.present?"
true
```
