### PR TITLE
Properly handle ActiveRecord::Base.connected?

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -88,11 +88,20 @@ module Octopus::Model
         end
       end
 
+      def self.connected_with_octopus?
+        if should_use_normal_connection?
+          connected_without_octopus?
+        else
+          connection_proxy.connected?
+        end
+      end
+
       class << self
         alias_method_chain :connection, :octopus
         alias_method_chain :connection_pool, :octopus
         alias_method_chain :clear_all_connections!, :octopus
         alias_method_chain :clear_active_connections!, :octopus
+        alias_method_chain :connected?, :octopus
       end
     end
   end

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -22,7 +22,7 @@ class Octopus::Proxy
     shards_config ||= []
 
     shards_config.each do |key, value|
-      if value.is_a?(String) 
+      if value.is_a?(String)
         value = resolve_string_connection(value).merge(:octopus_shard => key)
         initialize_adapter(value['adapter'])
         @shards[key.to_sym] = connection_pool_for(value, "#{value['adapter']}_connection")
@@ -138,7 +138,7 @@ class Octopus::Proxy
   # Rails 3.1 sets automatic_reconnect to false when it removes
   # connection pool.  Octopus can potentially retain a reference to a closed
   # connection pool.  Previously, that would work since the pool would just
-  # reconnect, but in Rails 3.1 the flag prevents this.  
+  # reconnect, but in Rails 3.1 the flag prevents this.
   def safe_connection(connection_pool)
     connection_pool.automatic_reconnect ||= true
     connection_pool.connection()
@@ -238,6 +238,10 @@ class Octopus::Proxy
 
   def clear_all_connections!
     @shards.each { |k, v| v.disconnect! }
+  end
+
+  def connected?
+    @shards.any? { |k, v| v.connected? }
   end
 
   protected

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -285,5 +285,15 @@ describe Octopus::Proxy do
       Item.using(:brazil).new(:name => 'Another Brazil Item').connection.select_connection.should_not eq(@item_brazil_conn)
       Item.using(:canada).new(:name => 'Another Canada Item').connection.select_connection.should_not eq(@item_canada_conn)
     end
+
+    it "is consistent with connected?" do
+      Item.connected?.should be_true
+      ActiveRecord::Base.connected?.should be_true
+
+      Item.clear_all_connections!
+
+      Item.connected?.should be_false
+      ActiveRecord::Base.connected?.should be_false
+    end
   end
 end


### PR DESCRIPTION
I noticed that with Octopus, `ActiveRecord::Base.connected?` always returns `false`.

This lead to some micro weirdness and among them the most annoying being the lack of AR timing in the logs : 

```
Completed 200 OK in 597ms (Views: 87.0ms | Solr: 0.0ms)
# instead of
Completed 200 OK in 597ms (Views: 87.0ms | ActiveRecord: 31.9ms | Solr: 0.0ms)
```

(See at https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railties/controller_runtime.rb)
