### PR TITLE
Make .touch timing spec work in all time zones

### DIFF
--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -361,14 +361,14 @@ describe Octopus::Model do
         @user = User.using(:brazil).create!(:name => "User1")
         User.using(:brazil).update_all({:updated_at => Time.now - 3.months}, {:id => @user.id})
         @user.touch
-        @user.reload.updated_at.to_date.should eq(Date.today)
+        @user.reload.updated_at.in_time_zone('GMT').to_date.should eq(Time.now.in_time_zone('GMT').to_date)
       end
 
       it "updates passed in attribute name" do
         @user = User.using(:brazil).create!(:name => "User1")
         User.using(:brazil).update_all({:created_at => Time.now - 3.months}, {:id => @user.id})
         @user.touch(:created_at)
-        @user.reload.created_at.to_date.should eq(Date.today)
+        @user.reload.created_at.in_time_zone('GMT').to_date.should eq(Time.now.in_time_zone('GMT').to_date)
       end
     end
 


### PR DESCRIPTION
These two specs were failing for me (in GMT-0500) with an error message like this:

```
  1) Octopus::Model AR basic methods touch updates updated_at by default
     Failure/Error: @user.reload.updated_at.to_date.should eq(Date.today)

       expected: Tue, 11 Feb 2014
            got: Wed, 12 Feb 2014

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Tue, 11 Feb 2014
       +Wed, 12 Feb 2014

     # ./spec/octopus/model_spec.rb:364:in `block (4 levels) in <top (required)>'
```
