### PR TITLE
Relation proxy changes

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -1,39 +1,9 @@
 module Octopus
-  class RelationProxy
-    include Octopus::ShardTracking::Attribute
-
-    attr_accessor :ar_relation
-
-    def initialize(shard, ar_relation)
-      @current_shard = shard
-      @ar_relation = ar_relation
+  module Relation
+    def self.included(base)
+      base.send(:include, Octopus::ShardTracking::Attribute)
     end
-
-    def method_missing(method, *args, &block)
-      run_on_shard { @ar_relation.send(method, *args, &block) }
-    end
-
-    def respond_to?(*args)
-      super || @ar_relation.respond_to?(*args)
-    end
-
-    # these methods are not normally sent to method_missing
-    def inspect
-      method_missing(:inspect)
-    end
-
-    def as_json(options = nil)
-      method_missing(:as_json, options)
-    end
-
-    def ==(other)
-      case other
-      when Octopus::RelationProxy
-        method_missing(:==, other.ar_relation)
-      else
-        method_missing(:==, other)
-      end
-    end
-    alias :eql? :==
   end
 end
+
+ActiveRecord::Relation.send(:include, Octopus::Relation)

--- a/lib/octopus/shard_tracking.rb
+++ b/lib/octopus/shard_tracking.rb
@@ -25,19 +25,18 @@ module Octopus::ShardTracking
 
   # Adds run_on_shard method, but does not implement current_shard method
   def run_on_shard(&block)
-    cs = current_shard
-    if !!cs
-      r = ActiveRecord::Base.connection_proxy.run_queries_on_shard(current_shard, &block)
+    if !!current_shard
+      result = ActiveRecord::Base.connection_proxy.run_queries_on_shard(current_shard, &block)
+
       # Use a case statement to avoid any path through ActiveRecord::Delegation's
       # respond_to? code. We want to avoid the respond_to? code because it can have
       # the side effect of causing a call to load_target
-      # return r
-      case r
+      case result
       when ActiveRecord::Relation
-        Octopus::RelationProxy.new(cs, r)
-      else
-        r
+        result.current_shard = current_shard
       end
+
+      result
     else
       yield
     end

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -73,5 +73,11 @@ describe Octopus::RelationProxy do
         end
       end
     end
+
+    context "when relation is passed as argument" do
+      it "does not fail" do
+        @client.items.where(id: @relation).count.should eq(1)
+      end
+    end
   end
 end

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Octopus::RelationProxy do
+describe Octopus::Relation do
   describe "shard tracking" do
     before :each do
       @client = Client.using(:canada).create!
@@ -12,6 +12,12 @@ describe Octopus::RelationProxy do
       @relation.current_shard.should eq(:canada)
     end
 
+    it "is equal to an identically-defined, but different, RelationProxy" do
+      i = @client.items
+      @relation.should eq(i)
+      @relation.object_id.should eq(i.object_id)
+    end
+
     context "when comparing to other Relation objects" do
       before :each do
         @relation.reset
@@ -19,29 +25,6 @@ describe Octopus::RelationProxy do
 
       it "is equal to its clone" do
         @relation.should eq(@relation.clone)
-      end
-    end
-
-    if Octopus.rails4?
-      context "under Rails 4" do
-        it "is an Octopus::RelationProxy" do
-          @relation.class.should eq(Octopus::RelationProxy)
-        end
-
-        it "should be able to return its ActiveRecord::Relation" do
-          @relation.ar_relation.is_a?(ActiveRecord::Relation).should be_true
-        end
-
-        it "is equal to an identically-defined, but different, RelationProxy" do
-          i = @client.items
-          @relation.should eq(i)
-          @relation.object_id.should_not eq(i.object_id)
-        end
-
-        it "is equal to its own underlying ActiveRecord::Relation" do
-          @relation.should eq(@relation.ar_relation)
-          @relation.ar_relation.should eq(@relation)
-        end
       end
     end
 


### PR DESCRIPTION
Hey @nickmarden! I've run into a bug with Octopus which I was struggling to fix during a few hours, and I'm sending this PR hoping you can clarify some things for me.

Consider this code:

```
@client = Client.using(:canada).create!
@client.items << Item.using(:canada).create!
@relation = @client.items
@client.items.where(id: @relation).count.should eq(1)
```

The last line raises ```NoMethodError: undefined method `visit_Octopus_RelationProxy' for #<Arel::Visitors::DepthFirst:0x007fb055867d30>``` on master. Apparently, this is caused by ```RelationProxy```.

I was trying to fix that and after some time of debugging I realized that the tests you've introduced in [this commit](https://github.com/curebit/octopus/commit/f29c32a0245028303da89e2f8cdbdd8a1684d7c0) are passing even when Octopus is set to not use ```RelationProxy``` instead of plain ```ActiveRecord::Relation```. I'm attaching commit that proves that and commit that adds _previously_ failing spec describing my problem (using ```where``` statement with relation as argument).

So, I would be really great if you can give me more details on what is ```RelationProxy``` purpose and how I can I properly test it, this would help me a lot in order to fix the bug described above.

Thank you. Cheers!