### PR TITLE
Simplify use of attr_accessor

### DIFF
--- a/lib/octopus/shard_tracking/attribute.rb
+++ b/lib/octopus/shard_tracking/attribute.rb
@@ -4,15 +4,9 @@
 module Octopus::ShardTracking::Attribute
   def self.included(base)
     base.send(:include, Octopus::ShardTracking)
-    base.extend(ClassMethods)
-    base.track_current_shard_as_attribute
   end
 
-  module ClassMethods
-    def track_current_shard_as_attribute
-      attr_accessor :current_shard
-    end
-  end
+  attr_accessor :current_shard
 
   def set_current_shard
     return unless Octopus.enabled?


### PR DESCRIPTION
Removing some metaprogramming that can be done much more simply.
