### PR TITLE
make instances of Octopus::RelationProxy have class equality with ActiveRecord::Relation

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -40,5 +40,27 @@ module Octopus
       end
     end
     alias_method :eql?, :==
+
+    def ===(other)
+      case other
+      when Octopus::RelationProxy
+        method_missing(:==, other.ar_relation)
+      else
+        method_missing(:==, other)
+      end
+    end
+
+    def is_a?(klass)
+      super || @ar_relation.is_a?(klass)
+    end
+  end
+end
+
+class ActiveRecord::Relation
+  class << self
+    alias_method :threequals_without_octopus, :===
+    def ===(other)
+      threequals_without_octopus(other) || (Octopus::RelationProxy === other && self === other.ar_relation)
+    end
   end
 end

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -12,6 +12,11 @@ describe Octopus::RelationProxy do
       expect(@relation.current_shard).to eq(:canada)
     end
 
+    it 'reports class equality with ActiveRecord::Relation' do
+      expect(@relation.ar_relation.class === @relation).to be_truthy
+      expect(@relation.is_a?(ActiveRecord::Relation)).to be_truthy
+    end
+
     context 'when comparing to other Relation objects' do
       before :each do
         @relation.reset


### PR DESCRIPTION
I'm seeing a problem in Octopus where it cannot handle relations passed where an id is expected, such as this:

``` ruby
Product.where(id: Product.on_sale)
```

Because of changes in rails, I believe Octopus::RelationProxy needs to respond true to both `relation.is_a?(ActiveRecord::Relation)` and `ActiveRecord::Relation === relation`.  In current beta releases of rails it uses `is_a?` (see https://github.com/rails/rails/blob/8c52480ba6071a12b97f124d9f21df2c39df3ed3/activerecord/lib/active_record/relation/query_methods.rb#L1154):

``` ruby
    def add_relations_to_bind_values(attributes)
      if attributes.is_a?(Hash)
        attributes.each_value do |value|
          if value.is_a?(ActiveRecord::Relation)
            self.bind_values += value.bind_values
          else
            add_relations_to_bind_values(value)
          end
        end
      end
```

In currently released rails versions, it uses `grep`, which just uses `===` (from https://github.com/rails/rails/blob/v4.1.5/activerecord/lib/active_record/relation/query_methods.rb#L937):

``` ruby
        values.grep(ActiveRecord::Relation) do |rel|
          self.bind_values += rel.bind_values
        end
```

This fix overrides `is_a?` on Octopus::RelationProxy and monkey-patches ActiveRecord::Relation so that it
