### PR TITLE
Avoid loading migrations' code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.1.6
   - 2.2.2
 gemfile:
+  - gemfiles/rails32.gemfile
   - gemfiles/rails4.gemfile
   - gemfiles/rails41.gemfile
   - gemfiles/rails42.gemfile
@@ -15,7 +16,3 @@ notifications:
   recipients:
     - gabriel.sobrinho@gmail.com
     - thiago.pradi@gmail.com
-matrix:
-  include:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails32.gemfile

--- a/README.mkdn
+++ b/README.mkdn
@@ -73,6 +73,20 @@ Octopus.using(:slave_two) do
 end
 ```
 
+If you want to use the same code for all shards or all shards in a specific group (for example in `db/seeds.rb`), you can use this syntax.
+
+```ruby
+# This will return a list of the given block's results, per shard.
+Octopus.using_all do
+  User.create_from_csv!
+end
+
+# This will return a list of the given block's results, per shard in history_shards group.
+Octopus.using_group(:history_shards) do
+  HistoryCategory.create_from_csv!
+end
+```
+
 Each model instance knows which shard it came from so this will work automatically:
 
 ```ruby
@@ -130,6 +144,19 @@ octopus:
 ```
 
 There is no need for a corresponding `default_migration_shard` - simply define that database to be your master. You might want this setting if all of your databases have identical schemas, but are not replicated.
+
+You can configure a master shard for the rails application, to connect to when rails is going up. The safest would be to configure this to the shard specified in `database.yml` (some things still use it).
+
+```yaml
+octopus:
+  master_shard: <%= ENV['SHARD'] || 'shard1' %>
+```
+
+Then you can use the `SHARD` environment variable to override the `master_shard` specified in `config/shards.yml`, useful for running rake tasks.
+
+```bash
+SHARD=shard1 rake db:setup && SHARD=shard2 rake db:setup
+```
 
 ### Rails Controllers
 

--- a/lib/octopus/abstract_adapter.rb
+++ b/lib/octopus/abstract_adapter.rb
@@ -20,20 +20,16 @@ module Octopus
         end
       end
 
-      def self.included(base)
-        base.alias_method_chain :initialize, :octopus_shard
-      end
-
       def octopus_shard
         @config[:octopus_shard]
       end
 
-      def initialize_with_octopus_shard(*args)
-        initialize_without_octopus_shard(*args)
+      def initialize(*args)
+        super
         @instrumenter = InstrumenterDecorator.new(self, @instrumenter)
       end
     end
   end
 end
 
-ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, Octopus::AbstractAdapter::OctopusShard)
+ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:prepend, Octopus::AbstractAdapter::OctopusShard)

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -6,6 +6,14 @@ module Octopus
   class Proxy
     attr_accessor :config, :sharded
 
+    CURRENT_MODEL_KEY = 'octopus.current_model'.freeze
+    CURRENT_SHARD_KEY = 'octopus.current_shard'.freeze
+    CURRENT_GROUP_KEY = 'octopus.current_group'.freeze
+    CURRENT_SLAVE_GROUP_KEY = 'octopus.current_slave_group'.freeze
+    BLOCK_KEY = 'octopus.block'.freeze
+    LAST_CURRENT_SHARD_KEY = 'octopus.last_current_shard'.freeze
+    FULLY_REPLICATED_KEY = 'octopus.fully_replicated'.freeze
+
     def initialize(config = Octopus.config)
       initialize_shards(config)
       initialize_replication(config) if !config.nil? && config['replicated']
@@ -90,20 +98,20 @@ module Octopus
     end
 
     def current_model
-      Thread.current['octopus.current_model']
+      Thread.current[CURRENT_MODEL_KEY]
     end
 
     def current_model=(model)
-      Thread.current['octopus.current_model'] = model.is_a?(ActiveRecord::Base) ? model.class : model
+      Thread.current[CURRENT_MODEL_KEY] = model.is_a?(ActiveRecord::Base) ? model.class : model
     end
 
     def current_shard
-      Thread.current['octopus.current_shard'] ||= Octopus.master_shard
+      Thread.current[CURRENT_SHARD_KEY] ||= Octopus.master_shard
     end
 
     def current_shard=(shard_symbol)
-      self.current_slave_group = nil
       if shard_symbol.is_a?(Array)
+        self.current_slave_group = nil
         shard_symbol.each { |symbol| fail "Nonexistent Shard Name: #{symbol}" if @shards[symbol].nil? }
       elsif shard_symbol.is_a?(Hash)
         hash = shard_symbol
@@ -123,17 +131,17 @@ module Octopus
               (@shards_slave_groups.try(:[], shard_symbol).nil? && @slave_groups[slave_group_symbol].nil?)
             fail "Nonexistent Slave Group Name: #{slave_group_symbol} in shards config: #{@shards_config.inspect}"
           end
-          self.current_slave_group = slave_group_symbol
         end
+        self.current_slave_group = slave_group_symbol
       else
         fail "Nonexistent Shard Name: #{shard_symbol}" if @shards[shard_symbol].nil?
       end
 
-      Thread.current['octopus.current_shard'] = shard_symbol
+      Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end
 
     def current_group
-      Thread.current['octopus.current_group']
+      Thread.current[CURRENT_GROUP_KEY]
     end
 
     def current_group=(group_symbol)
@@ -142,35 +150,35 @@ module Octopus
         fail "Nonexistent Group Name: #{group}" unless has_group?(group)
       end
 
-      Thread.current['octopus.current_group'] = group_symbol
+      Thread.current[CURRENT_GROUP_KEY] = group_symbol
     end
 
     def current_slave_group
-      Thread.current['octopus.current_slave_group']
+      Thread.current[CURRENT_SLAVE_GROUP_KEY]
     end
 
     def current_slave_group=(slave_group_symbol)
-      Thread.current['octopus.current_slave_group'] = slave_group_symbol
+      Thread.current[CURRENT_SLAVE_GROUP_KEY] = slave_group_symbol
     end
 
     def block
-      Thread.current['octopus.block']
+      Thread.current[BLOCK_KEY]
     end
 
     def block=(block)
-      Thread.current['octopus.block'] = block
+      Thread.current[BLOCK_KEY] = block
     end
 
     def last_current_shard
-      Thread.current['octopus.last_current_shard']
+      Thread.current[LAST_CURRENT_SHARD_KEY]
     end
 
     def last_current_shard=(last_current_shard)
-      Thread.current['octopus.last_current_shard'] = last_current_shard
+      Thread.current[LAST_CURRENT_SHARD_KEY] = last_current_shard
     end
 
     def fully_replicated?
-      @fully_replicated || Thread.current['octopus.fully_replicated']
+      @fully_replicated || Thread.current[FULLY_REPLICATED_KEY]
     end
 
     # Public: Whether or not a group exists with the given name converted to a
@@ -478,6 +486,7 @@ module Octopus
     # Temporarily switch `current_shard` and run the block
     def using_shard(shard, &_block)
       older_shard = current_shard
+      older_slave_group = current_slave_group
 
       begin
         unless current_model && !current_model.allowed_shard?(shard)
@@ -486,6 +495,7 @@ module Octopus
         yield
       ensure
         self.current_shard = older_shard
+        self.current_slave_group = older_slave_group
       end
     end
 

--- a/lib/octopus/railtie.rb
+++ b/lib/octopus/railtie.rb
@@ -1,6 +1,4 @@
 begin
-  require 'rails/railtie'
-
   module Octopus
     class Railtie < Rails::Railtie
       rake_tasks do

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -17,7 +17,7 @@ module Octopus
     end
 
     def method_missing(method, *args, &block)
-      run_on_shard { @ar_relation.public_send(method, *args, &block) }
+      @ar_relation.public_send(method, *args, &block)
     end
 
     def ==(other)

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -73,6 +73,15 @@ describe Octopus::RelationProxy do
         end
       end
 
+      it 'uses the correct shard in block when method_missing is triggered on CollectionProxy objects' do
+        Octopus.using(:brazil) do
+          @client.items.each do |item|
+            expect(item.current_shard).to eq(:canada)
+            expect(ActiveRecord::Base.connection.current_shard).to eq(:brazil)
+          end
+        end
+      end
+
       it 'lazily evaluates on the correct shard' do
         expect(Item.using(:brazil).count).to eq(0)
         Octopus.using(:brazil) do


### PR DESCRIPTION
With long running projects migrations might not load (require missing files, or worst - change models).
Rails doesn't require migrations code unless required, we should thrive to that.

This commit avoids loading migrations by checking the 'migrated' list first.
It will actually show migrations that don't belong to the shard but ran on that shard (might still want to rollback in that case, good that it appears on the list).
The second option is to declare in the configuration that the migrations are shard agnostic, which will prevent this check completely.

You can choose one of the two options, both good enough for my project.
