### PR TITLE
add #using_group and #using_all ability

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -73,6 +73,20 @@ Octopus.using(:slave_two) do
 end
 ```
 
+If you want to use the same code for all shards or all shards in a specific group (for example in `db/seeds.rb`), you can use this syntax.
+
+```ruby
+# This will return a list of the given block's results, per shard.
+Octopus.using_all do
+  User.create_from_csv!
+end
+
+# This will return a list of the given block's results, per shard in history_shards group.
+Octopus.using_group(:history_shards) do
+  HistoryCategory.create_from_csv!
+end
+```
+
 Each model instance knows which shard it came from so this will work automatically:
 
 ```ruby

--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -95,6 +95,26 @@ module Octopus
     end
   end
 
+  def self.using_group(group, &block)
+    conn = ActiveRecord::Base.connection
+
+    if conn.is_a?(Octopus::Proxy)
+      conn.send_queries_to_group(group, &block)
+    else
+      yield
+    end
+  end
+
+  def self.using_all(&block)
+    conn = ActiveRecord::Base.connection
+
+    if conn.is_a?(Octopus::Proxy)
+      conn.send_queries_to_all_shards(&block)
+    else
+      yield
+    end
+  end
+
   def self.fully_replicated(&_block)
     old_fully_replicated = Thread.current['octopus.fully_replicated']
     Thread.current['octopus.fully_replicated'] = true

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -226,9 +226,19 @@ module Octopus
     end
 
     def send_queries_to_multiple_shards(shards, &block)
-      shards.each do |shard|
+      shards.map do |shard|
         run_queries_on_shard(shard, &block)
       end
+    end
+
+    def send_queries_to_group(group, &block)
+      using_group(group) do
+        send_queries_to_multiple_shards(shards_for_group(group), &block)
+      end
+    end
+
+    def send_queries_to_all_shards(&block)
+      send_queries_to_multiple_shards(shard_names.uniq { |shard_name| @shards[shard_name] }, &block)
     end
 
     def clean_connection_proxy
@@ -429,6 +439,18 @@ module Octopus
         yield
       ensure
         self.current_shard = older_shard
+      end
+    end
+
+    # Temporarily switch `current_group` and run the block
+    def using_group(group, &_block)
+      older_group = current_group
+
+      begin
+        self.current_group = group
+        yield
+      ensure
+        self.current_group = older_group
       end
     end
 


### PR DESCRIPTION
Good for using within ```db/seeds.rb```.
```using_all``` filters out duplicates in case the master shard is one of the shards in ```config/shards.yml``` (see tchandy/octopus#270).
Also, ```Octopus::Proxy#send_queries_to_multiple_shards``` should return the results.