### PR TITLE
Allow indifferent access for url-based config

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -344,14 +344,14 @@ module Octopus
     def resolve_string_connection(spec)
       if Octopus.rails41?
         resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new({})
-        resolver.spec(spec).config.stringify_keys
+        HashWithIndifferentAccess.new(resolver.spec(spec).config)
       else
         if Octopus.rails4?
           resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(spec, {})
         else
           resolver = ActiveRecord::Base::ConnectionSpecification::Resolver.new(spec, {})
         end
-        resolver.spec.config.stringify_keys
+        HashWithIndifferentAccess.new(resolver.spec.config)
       end
     end
 


### PR DESCRIPTION
ConnectionPool.new is expecting to be able to access the config with symbolized keys. Prior to this fix, this was causing any connection pool settings to be ignored.

Most adapters avoid this issue by calling symbolize_keys before attempting to connect, so the connection still works.
