### PR TITLE
disabling association shard tracking causes no test failures

### DIFF
--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -96,7 +96,7 @@ module Octopus
         options[:before_remove] = :connection_on_association=
       end
 
-      options[:extend] = [Octopus::AssociationShardTracking::QueryOnCurrentShard, options[:extend]].flatten.compact
+      # options[:extend] = [Octopus::AssociationShardTracking::QueryOnCurrentShard, options[:extend]].flatten.compact
     end
   end
 end


### PR DESCRIPTION
Just want to demonstrate that removing association shard tracking causes no test failures.  I don't know if this means that the original problem it was added to solve has been fixed by some other means.
