### PR TITLE
Fix collection association with the same name as ancestor private method.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,6 +127,7 @@ namespace :db do
         u.string :name
         u.string :commentable_type
         u.integer :commentable_id
+        u.boolean :open, default: false
       end
 
       BlankModel.using(shard_symbol).connection.create_table(:parts) do |u|

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -17,7 +17,7 @@ module Octopus
     end
 
     def method_missing(method, *args, &block)
-      run_on_shard { @ar_relation.send(method, *args, &block) }
+      run_on_shard { @ar_relation.public_send(method, *args, &block) }
     end
 
     def ==(other)

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -12,6 +12,13 @@ describe Octopus::RelationProxy do
       expect(@relation.current_shard).to eq(:canada)
     end
 
+    unless Octopus.rails3?
+      it 'can define collection association with the same name as ancestor private method' do
+        @client.comments << Comment.using(:canada).create!(open: true)
+        expect(@client.comments.open).to be_a_kind_of(ActiveRecord::Relation)
+      end
+    end
+
     context 'when comparing to other Relation objects' do
       before :each do
         @relation.reset

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -76,6 +76,7 @@ end
 
 class Comment < ActiveRecord::Base
   belongs_to :commentable, :polymorphic => true
+  scope :open, -> { where(open: true) }
 end
 
 class Bacon < ActiveRecord::Base


### PR DESCRIPTION
When I define a scope with the same name as the ancestor private method.
Such as `open`. It will cause an error.

``` ruby
class Client
  has_many :comments
end

class Comment
  belongs_to :client
  scope :open, -> { where(open: true) }
end
```

```
> client.comments.open
ArgumentError:
       wrong number of arguments (0 for 1..3)
     # ./lib/octopus/relation_proxy.rb:20:in `initialize'
     # ./lib/octopus/relation_proxy.rb:20:in `open'
     # ./lib/octopus/relation_proxy.rb:20:in `block in method_missing'
     # ./lib/octopus/proxy.rb:226:in `block (2 levels) in run_queries_on_shard'
     # ./lib/octopus/proxy.rb:476:in `using_shard'
     # ./lib/octopus/proxy.rb:225:in `block in run_queries_on_shard'
     # ./lib/octopus/proxy.rb:462:in `keeping_connection_proxy'
     # ./lib/octopus/proxy.rb:224:in `run_queries_on_shard'
     # ./lib/octopus/shard_tracking.rb:30:in `run_on_shard'
     # ./lib/octopus/relation_proxy.rb:20:in `method_missing'
     # ./spec/octopus/relation_proxy_spec.rb:17:in `block (3 levels) in <top (required)>'
```

Use `public_send` instead of `send` to avoid this problem.

**Update**
It seems that rails3 also has the same problem:
https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/associations/collection_proxy.rb#L102
So I skip the test on rails3.
