### PR TITLE
Replace Module#include & alias_method_chain with Module#prepend & super

### DIFF
--- a/lib/octopus/abstract_adapter.rb
+++ b/lib/octopus/abstract_adapter.rb
@@ -20,20 +20,16 @@ module Octopus
         end
       end
 
-      def self.included(base)
-        base.alias_method_chain :initialize, :octopus_shard
-      end
-
       def octopus_shard
         @config[:octopus_shard]
       end
 
-      def initialize_with_octopus_shard(*args)
-        initialize_without_octopus_shard(*args)
+      def initialize(*args)
+        super
         @instrumenter = InstrumenterDecorator.new(self, @instrumenter)
       end
     end
   end
 end
 
-ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, Octopus::AbstractAdapter::OctopusShard)
+ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:prepend, Octopus::AbstractAdapter::OctopusShard)


### PR DESCRIPTION
As of ruby 2.0, `Module` supports `#prepend`, which allows derivation-style overriding using `super`, rather than the old-style insertion and `alias_method_chain` hack.  See, e.g., [this blog post](http://dev.af83.com/2012/10/19/ruby-2-0-module-prepend.html)

Aside from being generally cleaner, and the direction [rails is going](http://weblog.rubyonrails.org/2015/3/27/this-week-in-rails-goodbye-alias_method_chain-postgresql-typecasting-and-more/), this PR specifically fixes the inifinite recursion reported in SchemaPlus/schema_monkey#4
