### PR TITLE
Detect Rails environment using environment variables too

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -11,7 +11,7 @@ module Octopus
   end
 
   def self.rails_env
-    @rails_env ||= self.rails? ? Rails.env.to_s : 'shards'
+    @rails_env ||= (Rails.env.to_s if self.rails?) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] || 'shards'
   end
 
   def self.config

--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -34,8 +34,8 @@ module Octopus
   #
   # Returns a boolean
   def self.enabled?
-    if defined?(::Rails)
-      Octopus.environments.include?(Rails.env.to_s)
+    if self.rails_env != 'shards'
+      Octopus.environments.include?(self.rails_env)
     else
       # TODO: This doens't feel right but !Octopus.config.blank? is breaking a
       #       test. Also, Octopus.config is always returning a hash.

--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -46,7 +46,7 @@ module Octopus
   # Returns the Rails.root_to_s when you are using rails
   # Running the current directory in a generic Ruby process
   def self.directory
-    @directory ||= defined?(Rails) ?  Rails.root.to_s : Dir.pwd
+    @directory ||= self.rails? ?  Rails.root.to_s : Dir.pwd
   end
 
   # This is the default way to do Octopus Setup
@@ -97,7 +97,7 @@ module Octopus
   attr_writer :logger
 
   def self.logger
-    if defined?(Rails)
+    if self.rails?
       @logger ||= Rails.logger
     else
       @logger ||= Logger.new($stderr)


### PR DESCRIPTION
The ActiveRecord gem itself, doesn't rely solely on the existence of the ```Rails``` module.

Instead, it performs checks in the following order:
- does the ```Rails``` module exist? if so, use the value of the ```Rails.env``` method, if not...
- is the ```RAILS_ENV``` environment variable set? if so, use its value, if not...
- is the ```RACK_ENV``` environment variable set? if so, use its value, if not...
- default to a string with a value of ```default_env```

This pull request performs the same logic, and replaces the ```defined?(::Rails)``` calls, with a call to our own ```rails_env``` method.

The only thing I'm a little iffy on is the ```Octopus#enabled?``` method.

The original code logic says if the ```Rails``` module exists, then we return a boolean that says if our environment is included in the Octopus configurations. In order for me to replicate the same behavior when the environment is passed in via an environment variable, I have to do a string comparison of the return result from ```Octopus#rails_env``` to specifically make sure it's not set to ```shards```.

Thoughts?