### PR TITLE
Avoid unnecessary string allocations

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -120,11 +120,11 @@ module Octopus
   end
 
   def self.fully_replicated(&_block)
-    old_fully_replicated = Thread.current['octopus.fully_replicated']
-    Thread.current['octopus.fully_replicated'] = true
+    old_fully_replicated = Thread.current[Octopus::Proxy::FULLY_REPLICATED_KEY]
+    Thread.current[Octopus::Proxy::FULLY_REPLICATED_KEY] = true
     yield
   ensure
-    Thread.current['octopus.fully_replicated'] = old_fully_replicated
+    Thread.current[Octopus::Proxy::FULLY_REPLICATED_KEY] = old_fully_replicated
   end
 end
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -6,6 +6,14 @@ module Octopus
   class Proxy
     attr_accessor :config, :sharded
 
+    CURRENT_MODEL_KEY = 'octopus.current_model'.freeze
+    CURRENT_SHARD_KEY = 'octopus.current_shard'.freeze
+    CURRENT_GROUP_KEY = 'octopus.current_group'.freeze
+    CURRENT_SLAVE_GROUP_KEY = 'octopus.current_slave_group'.freeze
+    BLOCK_KEY = 'octopus.block'.freeze
+    LAST_CURRENT_SHARD_KEY = 'octopus.last_current_shard'.freeze
+    FULLY_REPLICATED_KEY = 'octopus.fully_replicated'.freeze
+
     def initialize(config = Octopus.config)
       initialize_shards(config)
       initialize_replication(config) if !config.nil? && config['replicated']
@@ -90,15 +98,15 @@ module Octopus
     end
 
     def current_model
-      Thread.current['octopus.current_model']
+      Thread.current[CURRENT_MODEL_KEY]
     end
 
     def current_model=(model)
-      Thread.current['octopus.current_model'] = model.is_a?(ActiveRecord::Base) ? model.class : model
+      Thread.current[CURRENT_MODEL_KEY] = model.is_a?(ActiveRecord::Base) ? model.class : model
     end
 
     def current_shard
-      Thread.current['octopus.current_shard'] ||= :master
+      Thread.current[CURRENT_SHARD_KEY] ||= :master
     end
 
     def current_shard=(shard_symbol)
@@ -129,11 +137,11 @@ module Octopus
         fail "Nonexistent Shard Name: #{shard_symbol}" if @shards[shard_symbol].nil?
       end
 
-      Thread.current['octopus.current_shard'] = shard_symbol
+      Thread.current[CURRENT_SHARD_KEY] = shard_symbol
     end
 
     def current_group
-      Thread.current['octopus.current_group']
+      Thread.current[CURRENT_GROUP_KEY]
     end
 
     def current_group=(group_symbol)
@@ -142,35 +150,35 @@ module Octopus
         fail "Nonexistent Group Name: #{group}" unless has_group?(group)
       end
 
-      Thread.current['octopus.current_group'] = group_symbol
+      Thread.current[CURRENT_GROUP_KEY] = group_symbol
     end
 
     def current_slave_group
-      Thread.current['octopus.current_slave_group']
+      Thread.current[CURRENT_SLAVE_GROUP_KEY]
     end
 
     def current_slave_group=(slave_group_symbol)
-      Thread.current['octopus.current_slave_group'] = slave_group_symbol
+      Thread.current[CURRENT_SLAVE_GROUP_KEY] = slave_group_symbol
     end
 
     def block
-      Thread.current['octopus.block']
+      Thread.current[BLOCK_KEY]
     end
 
     def block=(block)
-      Thread.current['octopus.block'] = block
+      Thread.current[BLOCK_KEY] = block
     end
 
     def last_current_shard
-      Thread.current['octopus.last_current_shard']
+      Thread.current[LAST_CURRENT_SHARD_KEY]
     end
 
     def last_current_shard=(last_current_shard)
-      Thread.current['octopus.last_current_shard'] = last_current_shard
+      Thread.current[LAST_CURRENT_SHARD_KEY] = last_current_shard
     end
 
     def fully_replicated?
-      @fully_replicated || Thread.current['octopus.fully_replicated']
+      @fully_replicated || Thread.current[FULLY_REPLICATED_KEY]
     end
 
     # Public: Whether or not a group exists with the given name converted to a


### PR DESCRIPTION
The memory_profiler gem indicates that these string allocations make up a significant
proportion of our overall allocations on our production Rails app