### PR TITLE
add support for being able to plug in custom load balancer

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -28,6 +28,14 @@ module Octopus
     end
   end
 
+  def self.load_balancer=(balancer)
+    @load_balancer = balancer
+  end
+
+  def self.load_balancer
+    @load_balancer ||= Octopus::LoadBalancing::RoundRobin
+  end
+
   def self.master_shard
     ((config && config[:master_shard]) || :master).to_sym
   end

--- a/lib/octopus/load_balancing/round_robin.rb
+++ b/lib/octopus/load_balancing/round_robin.rb
@@ -11,7 +11,7 @@ module Octopus
       end
 
       # Returns the next available slave in the pool
-      def next
+      def next(options)
         @slaves_list[@slave_index = (@slave_index + 1) % @slaves_list.length]
       end
     end

--- a/lib/octopus/slave_group.rb
+++ b/lib/octopus/slave_group.rb
@@ -3,11 +3,11 @@ module Octopus
     def initialize(slaves)
       slaves = HashWithIndifferentAccess.new(slaves)
       slaves_list = slaves.values
-      @load_balancer = Octopus::LoadBalancing::RoundRobin.new(slaves_list)
+      @load_balancer = Octopus.load_balancer.new(slaves_list)
     end
 
-    def next
-      @load_balancer.next
+    def next(options)
+      @load_balancer.next options
     end
   end
 end


### PR DESCRIPTION
This feature is a minor change to support people adding their own custom load balancers for slave groups (Octopus::LoadBalancing::RoundRobin is still the default load balancer). In order to do so, you do
Octopus.load_balancer = MyCustomLoadBalancer where MyCustomLoadBalancer is a class that implements an initialize method accepting a slave group and a next method accepting an optional hash of options. 

In this feature, users also have the ability to pass options to their custom load balancers by specifying a key called load_balancer_options like in the following example:

Octopus.using(:slave_group => :slave_group_a, :load_balance_options => {:enforce_best_available => true}){Customer.first}

I am currently using this to be able to have a custom load balancer that periodically checks the status of each slave and temporarily removes them from round robining if they are lagging too far behind master.