### PR TITLE
Create a custom exception for mismatched shards on associations

### DIFF
--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -1,5 +1,23 @@
 module Octopus
   module AssociationShardTracking
+    class MismatchedShards < StandardError
+      attr_reader :record, :current_shard
+
+      def initialize(record, current_shard)
+        @record = record
+        @current_shard = current_shard
+      end
+
+      def message
+        [
+          "Association Error: Records are from different shards",
+          "Record: #{record.inspect}",
+          "Current Shard: #{current_shard.inspect}",
+          "Current Record Shard: #{record.current_shard.inspect}",
+        ].join(" ")
+      end
+    end
+
     def self.extended(base)
       base.send(:include, InstanceMethods)
     end
@@ -8,8 +26,9 @@ module Octopus
       def connection_on_association=(record)
         return unless ::Octopus.enabled?
         return if !self.class.connection.respond_to?(:current_shard) || !self.respond_to?(:current_shard)
+
         if !record.current_shard.nil? && !current_shard.nil? && record.current_shard != current_shard
-          fail 'Association Error: Records are from different shards'
+          raise MismatchedShards.new(record, current_shard)
         end
 
         record.current_shard = self.class.connection.current_shard = current_shard if should_set_current_shard?

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -399,7 +399,7 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
     it 'should raise error if you try to add a record from a different shard' do
       expect do
         @brazil_client.items << Item.using(:canada).create!(:name => 'New User')
-      end.to raise_error('Association Error: Records are from different shards')
+      end.to raise_error(Octopus::AssociationShardTracking::MismatchedShards)
     end
 
     it 'should update the attribute for the item' do


### PR DESCRIPTION
The new error message includes the record, current_shard and the
record's current_shard. This should help users debug which record is
mismatched as well as what shards are involved in the issue.
