### PR TITLE
workaround for Marshal.dump to work in Ruby 2.3

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -16,6 +16,10 @@ module Octopus
       @ar_relation = ar_relation
     end
 
+    def respond_to?(*args)
+      method_missing(:respond_to?, *args)
+    end
+
     def method_missing(method, *args, &block)
       if block
         @ar_relation.public_send(method, *args, &block)

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -12,6 +12,10 @@ describe Octopus::RelationProxy do
       expect(@relation.current_shard).to eq(:canada)
     end
 
+    it 'can be dumped and loaded' do
+      expect(Marshal.load(Marshal.dump(@relation))).to eq @relation
+    end
+
     unless Octopus.rails3?
       it 'can define collection association with the same name as ancestor private method' do
         @client.comments << Comment.using(:canada).create!(open: true)


### PR DESCRIPTION
A change in Ruby 2.3 made it so that Marshal.dump does not work on things that inherit from BasicObject unless they define a respond_to? method: https://bugs.ruby-lang.org/issues/12353