### PR TITLE
Support relation.where.not(...) when proxying relations for shard tracking

### DIFF
--- a/lib/octopus/shard_tracking.rb
+++ b/lib/octopus/shard_tracking.rb
@@ -24,6 +24,8 @@ module Octopus
       end
     end
 
+    IMPLEMENTS_WHERE_CHAIN = Octopus.rails4?
+
     # Adds run_on_shard method, but does not implement current_shard method
     def run_on_shard(&block)
       if (cs = current_shard)
@@ -31,8 +33,11 @@ module Octopus
         # Use a case statement to avoid any path through ActiveRecord::Delegation's
         # respond_to? code. We want to avoid the respond_to? code because it can have
         # the side effect of causing a call to load_target
-        r = Octopus::RelationProxy.new(cs, r) if ActiveRecord::Relation === r and not Octopus::RelationProxy === r
-        r
+        if (ActiveRecord::Relation === r || (IMPLEMENTS_WHERE_CHAIN && ActiveRecord::QueryMethods::WhereChain === r)) && !(Octopus::RelationProxy === r)
+          Octopus::RelationProxy.new(cs, r)
+        else
+          r
+        end
       else
         yield
       end

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -49,6 +49,13 @@ describe Octopus::RelationProxy do
           expect(@relation).to eq(@relation.ar_relation)
           expect(@relation.ar_relation).to eq(@relation)
         end
+
+        it 'maintains the current shard when using where.not(...)' do
+          where_chain = @relation.where
+          expect(where_chain.current_shard).to eq(@relation.current_shard)
+          not_relation = where_chain.not("1=0")
+          expect(not_relation.current_shard).to eq(@relation.current_shard)
+        end
       end
     end
 


### PR DESCRIPTION
Currently chaining relations work like this:

```
relation = Model.where(...) # => result has a current_shard
relation.where(...) # => result keeps the same current_shard
```

but the following does not work:

```
relation.where # => # => result not wrapped and thus has no current_shard
relation.where.not(...) # => breaks because it's not wrapped and has no current_shard
```

The fix is relatively simple overall (we need to wrap `ActiveRecord::QueryMethods::WhereChain` as well as `ActiveRecord::Relation`, but it's also a bit complicated since the `WhereChain` only exists in Rails 4+.
