### PR TITLE
Remove deprecated alias_method_chain

### DIFF
--- a/lib/octopus/log_subscriber.rb
+++ b/lib/octopus/log_subscriber.rb
@@ -3,8 +3,12 @@ module Octopus
   module LogSubscriber
     def self.included(base)
       base.send(:attr_accessor, :octopus_shard)
-      base.alias_method_chain :sql, :octopus_shard
-      base.alias_method_chain :debug, :octopus_shard
+
+      base.send :alias_method, :sql_without_octopus_shard, :sql
+      base.send :alias_method, :sql, :sql_with_octopus_shard
+
+      base.send :alias_method, :debug_without_octopus_shard, :debug
+      base.send :alias_method, :debug, :debug_with_octopus_shard
     end
 
     def sql_with_octopus_shard(event)

--- a/lib/octopus/migration.rb
+++ b/lib/octopus/migration.rb
@@ -19,7 +19,9 @@ module Octopus
     def self.included(base)
       base.extend(ClassMethods)
 
-      base.alias_method_chain :announce, :octopus
+      base.send :alias_method, :announce_without_octopus, :announce
+      base.send :alias_method, :announce, :announce_with_octopus
+
       base.class_attribute :current_shard, :current_group, :current_group_specified, :instance_reader => false, :instance_writer => false
     end
 
@@ -64,16 +66,28 @@ module Octopus
 
       base.class_eval do
         class << self
-          alias_method_chain :migrate, :octopus
-          alias_method_chain :up, :octopus
-          alias_method_chain :down, :octopus
-          alias_method_chain :run, :octopus
+          alias_method :migrate_without_octopus, :migrate
+          alias_method :migrate, :migrate_with_octopus
+
+          alias_method :up_without_octopus, :up
+          alias_method :up, :up_with_octopus
+
+          alias_method :down_without_octopus, :down
+          alias_method :down, :down_with_octopus
+
+          alias_method :run_without_octopus, :run
+          alias_method :run, :run_with_octopus
         end
       end
 
-      base.alias_method_chain :run, :octopus
-      base.alias_method_chain :migrate, :octopus
-      base.alias_method_chain :migrations, :octopus
+      base.send :alias_method, :run_without_octopus, :run
+      base.send :alias_method, :run, :run_with_octopus
+
+      base.send :alias_method, :migrate_without_octopus, :migrate
+      base.send :alias_method, :migrate, :migrate_with_octopus
+
+      base.send :alias_method, :migrations_without_octopus, :migrations
+      base.send :alias_method, :migrations, :migrations_with_octopus
     end
 
     def run_with_octopus(&block)
@@ -151,7 +165,9 @@ end
 module Octopus
   module UnknownMigrationVersionError
     def self.included(base)
-      base.alias_method_chain :initialize, :octopus
+      base.send :alias_method, :initialize_without_octopus, :initialize
+      base.send :alias_method, :initialize, :initialize_with_octopus
+
       base.send(:attr_accessor, :version)
     end
 

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -45,7 +45,8 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
         base.send(:alias_method, :equality_without_octopus, :==)
         base.send(:alias_method, :==, :equality_with_octopus)
         base.send(:alias_method, :eql?, :==)
-        base.send(:alias_method_chain, :perform_validations, :octopus)
+        base.send(:alias_method, :perform_validations_without_octopus, :perform_validations)
+        base.send(:alias_method, :perform_validations, :perform_validations_with_octopus)
       end
 
       def set_current_shard
@@ -111,11 +112,20 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
         class << self
           attr_accessor :custom_octopus_table_name
 
-          alias_method_chain :connection, :octopus
-          alias_method_chain :connection_pool, :octopus
-          alias_method_chain :clear_all_connections!, :octopus
-          alias_method_chain :clear_active_connections!, :octopus
-          alias_method_chain :connected?, :octopus
+          alias_method :connection_without_octopus, :connection
+          alias_method :connection, :connection_with_octopus
+
+          alias_method :connection_pool_without_octopus, :connection_pool
+          alias_method :connection_pool, :connection_pool_with_octopus
+
+          alias_method :clear_all_connections_without_octopus!, :clear_all_connections!
+          alias_method :clear_all_connections!, :clear_all_connections_with_octopus!
+
+          alias_method :clear_active_connections_without_octopus!, :clear_active_connections!
+          alias_method :clear_active_connections!, :clear_active_connections_with_octopus!
+
+          alias_method :connected_without_octopus?, :connected?
+          alias_method :connected?, :connected_with_octopus?
 
           def table_name=(value = nil)
             self.custom_octopus_table_name = true

--- a/lib/octopus/shard_tracking.rb
+++ b/lib/octopus/shard_tracking.rb
@@ -20,7 +20,8 @@ module Octopus
         define_method with do |*args, &block|
           run_on_shard { send(without, *args, &block) }
         end
-        alias_method_chain name.to_sym, :octopus
+        alias_method without.to_sym, name.to_sym
+        alias_method name.to_sym, with.to_sym
       end
     end
 


### PR DESCRIPTION
Preferably would be to use `prepend` method, but since I'm unable to run specs (as it requires all db types), I'm using straightforward `alias_method`