### PR TITLE
Fix RSpec 'raise_error' warnings

### DIFF
--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -90,7 +90,7 @@ describe Octopus::Model do
         Octopus.using(:canada) do
           fail 'Some Exception'
         end
-      end.to raise_error
+      end.to raise_error(RuntimeError)
 
       expect(ActiveRecord::Base.connection.current_shard).to eq(:master)
     end
@@ -103,7 +103,7 @@ describe Octopus::Model do
           Octopus.using(:canada) do
             fail 'Some Exception'
           end
-        end.to raise_error
+        end.to raise_error(RuntimeError)
 
         expect(ActiveRecord::Base.connection.current_shard).to eq(:brazil)
         Octopus.config[:master_shard] = nil
@@ -665,13 +665,14 @@ describe Octopus::Model do
     it 'should work correctly when using validations' do
       @key = Keyboard.create!(:name => 'Key')
       expect { Keyboard.using(:brazil).create!(:name => 'Key') }.not_to raise_error
-      expect { Keyboard.create!(:name => 'Key') }.to raise_error
+      expect { Keyboard.create!(:name => 'Key') }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'should work correctly when using validations with using syntax' do
       @key = Keyboard.using(:brazil).create!(:name => 'Key')
       expect { Keyboard.create!(:name => 'Key') }.not_to raise_error
-      expect { Keyboard.using(:brazil).create!(:name => 'Key') }.to raise_error
+      expect { Keyboard.using(:brazil).create!(:name => 'Key') }
+        .to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/octopus/octopus_spec.rb
+++ b/spec/octopus/octopus_spec.rb
@@ -37,7 +37,7 @@ describe Octopus, :shards => [] do
     end
 
     it 'should permit users to configure shards on initializer files, instead of on a yml file.' do
-      expect { User.using(:crazy_shard).create!(:name => 'Joaquim') }.to raise_error
+      expect { User.using(:crazy_shard).create!(:name => 'Joaquim') }.to raise_error(RuntimeError)
 
       Octopus.setup do |config|
         config.shards = { :crazy_shard => { :adapter => 'mysql2', :database => 'octopus_shard_5', :username => 'root', :password => '' } }


### PR DESCRIPTION
An error message or a class has to be provided for the RSpec
matcher 'raise_error'. This commit fixes those warnings.

This is one of those warnings:
```shell
WARNING: Using the `raise_error` matcher without providing a specific error or
message risks false positives, since `raise_error` will match when Ruby raises a
`NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the
expectation to pass without even executing the method you are intending to call.
Actual error raised was #<RuntimeError: Nonexistent Shard Name: crazy_shard>.
Instead consider providing a specific error class or message. This message can be 
suppressed by setting:
`RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.

Called from /Users/projects/spec/octopus/octopus_spec.rb:40:in 
 `block (3 levels) in <top (required)>'.
```