### PR TITLE
Removing `last_current_shard` reference

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -51,13 +51,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
 
       def set_current_shard
         return unless Octopus.enabled?
-
-        if new_record? || self.class.connection_proxy.block
-          shard = self.class.connection_proxy.current_shard
-        else
-          shard = self.class.connection_proxy.last_current_shard || self.class.connection_proxy.current_shard
-        end
-
+        shard = self.class.connection_proxy.current_shard
         self.current_shard = shard if self.class.allowed_shard?(shard)
       end
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -12,7 +12,6 @@ module Octopus
     CURRENT_SLAVE_GROUP_KEY = 'octopus.current_slave_group'.freeze
     CURRENT_LOAD_BALANCE_OPTIONS_KEY = 'octopus.current_load_balance_options'.freeze
     BLOCK_KEY = 'octopus.block'.freeze
-    LAST_CURRENT_SHARD_KEY = 'octopus.last_current_shard'.freeze
     FULLY_REPLICATED_KEY = 'octopus.fully_replicated'.freeze
 
     def initialize(config = Octopus.config)
@@ -181,14 +180,6 @@ module Octopus
       Thread.current[BLOCK_KEY] = block
     end
 
-    def last_current_shard
-      Thread.current[LAST_CURRENT_SHARD_KEY]
-    end
-
-    def last_current_shard=(last_current_shard)
-      Thread.current[LAST_CURRENT_SHARD_KEY] = last_current_shard
-    end
-
     def fully_replicated?
       @fully_replicated || Thread.current[FULLY_REPLICATED_KEY]
     end
@@ -290,7 +281,6 @@ module Octopus
     def method_missing(method, *args, &block)
       if should_clean_connection_proxy?(method)
         conn = select_connection
-        self.last_current_shard = current_shard
         clean_connection_proxy
         conn.send(method, *args, &block)
       elsif should_send_queries_to_shard_slave_group?(method)


### PR DESCRIPTION

### Why
The semantics around choosing the `current_shard` on a model during `set_current_shard` have caused bugs in our application. This is because `current_shard` has been set the `last_current_shard` reference on the `Octopus::Proxy` object. 

It doesn't ever make sense to set the `current_shard` on a new object equal to the last shard that `Octopus::Proxy` connected to. It should always be set to the `Octopus::Proxy`'s `current_shard` object.

[The commit that adds the `last_current_shard`](https://github.com/thiagopradi/octopus/commit/bd80853d97cf928a4ff25b6444b0ff461f332856) reference to the `Octopus::Proxy` object provides no explanation or insight as to why it was added. Additionally no specs exist around `last_current_shard`.

Therefore it seems as though it should just be removed, and will fix a lot of issues.