### PR TITLE
Raise helpful error if no slaves are available

### DIFF
--- a/lib/octopus/load_balancing/round_robin.rb
+++ b/lib/octopus/load_balancing/round_robin.rb
@@ -6,6 +6,7 @@ module Octopus
   module LoadBalancing
     class RoundRobin
       def initialize(slaves_list)
+        raise Octopus::Exception.new("No slaves available") if slaves_list.empty?
         @slaves_list = slaves_list
         @slave_index = 0
       end

--- a/spec/octopus/load_balancing/round_robin_spec.rb
+++ b/spec/octopus/load_balancing/round_robin_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Octopus::LoadBalancing::RoundRobin do
+  it "raises an error when no shards are given" do
+    expect do
+      Octopus::LoadBalancing::RoundRobin.new([])
+    end.to raise_error Octopus::Exception
+  end
+
+  it "does not raise an error if slaves given" do
+    expect do
+      Octopus::LoadBalancing::RoundRobin.new([:stub])
+    end.to_not raise_error Octopus::Exception
+  end
+end


### PR DESCRIPTION
Currently, if you run an Octopus-enabled application with a shards.yml that is misconfigured to define zero slaves in the appropriate slave group, you get this error:

```
<path_to_gems>/ar-octopus-0.9.0/lib/octopus/load_balancing/round_robin.rb:15:in `%': divided by 0 (ZeroDivisionError)
        from /home/ubuntu/quottly-ng/.bundle/ruby/2.3.0/gems/ar-octopus-0.9.0/lib/octopus/load_balancing/round_robin.rb:15:in `next'
        from /home/ubuntu/quottly-ng/.bundle/ruby/2.3.0/gems/ar-octopus-0.9.0/lib/octopus/proxy.rb:441:in `send_queries_to_selected_slave'
```
This isn't particularly hard to track down, but it could be more helpful. 

I haven't yet run any tests here; but will run tests & update presently.