### PR TITLE
Removing method missing

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -27,7 +27,9 @@ module Octopus
       :type_cast, :to_sql, :quote, :quote_column_name, :quote_table_name,
       :quote_table_name_for_assignment, :supports_migrations?, :table_alias_for,
       :table_exists?, :in_clause_length, :supports_ddl_transactions?,
-      :sanitize_limit, :prefetch_primary_key?, to: :select_connection
+      :sanitize_limit, :prefetch_primary_key?, :current_database, :initialize_schema_migrations_table,
+      :combine_bind_parameters, :empty_insert_statement_value, :assume_migrated_upto_version,
+      :schema_cache, :substitute_at, to: :select_connection
 
     # Rails 3.1 sets automatic_reconnect to false when it removes
     # connection pool.  Octopus can potentially retain a reference to a closed

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -39,12 +39,6 @@ module Octopus
       conn.execute(sql, name)
     end
 
-    def delete(arel, name = nil, binds = [])
-      conn = select_connection
-      clean_connection_proxy
-      conn.delete(arel, name, binds)
-    end
-
     def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
       conn = select_connection
       clean_connection_proxy
@@ -55,6 +49,10 @@ module Octopus
       conn = select_connection
       clean_connection_proxy
       conn.update(arel, name, binds)
+    end
+
+    def delete(*args, &block)
+      legacy_method_missing_logic('delete', *args, &block)
     end
 
     def select_all(*args, &block)

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -20,6 +20,15 @@ module Octopus
       self.proxy_config = Octopus::ProxyConfig.new(config)
     end
 
+    # Rails Connection Methods - Those methods are overriden to add custom behavior that helps
+    # Octopus introduce Sharding / Replication.
+
+    delegate :adapter_name, :add_transaction_record, :case_sensitive_modifier,
+      :type_cast, :to_sql, :quote, :quote_column_name, :quote_table_name,
+      :quote_table_name_for_assignment, :supports_migrations?, :table_alias_for,
+      :table_exists?, :in_clause_length, :supports_ddl_transactions?,
+      :sanitize_limit, :prefetch_primary_key?, to: :select_connection
+
     # Rails 3.1 sets automatic_reconnect to false when it removes
     # connection pool.  Octopus can potentially retain a reference to a closed
     # connection pool.  Previously, that would work since the pool would just

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -22,14 +22,40 @@ module Octopus
 
     # Rails Connection Methods - Those methods are overriden to add custom behavior that helps
     # Octopus introduce Sharding / Replication.
-
     delegate :adapter_name, :add_transaction_record, :case_sensitive_modifier,
       :type_cast, :to_sql, :quote, :quote_column_name, :quote_table_name,
       :quote_table_name_for_assignment, :supports_migrations?, :table_alias_for,
       :table_exists?, :in_clause_length, :supports_ddl_transactions?,
       :sanitize_limit, :prefetch_primary_key?, :current_database, :initialize_schema_migrations_table,
       :combine_bind_parameters, :empty_insert_statement_value, :assume_migrated_upto_version,
-      :schema_cache, :substitute_at, to: :select_connection
+      :schema_cache, :substitute_at, :internal_string_options_for_primary_key, :lookup_cast_type_from_column,
+      :supports_advisory_locks?, :get_advisory_lock, :initialize_internal_metadata_table,
+      :release_advisory_lock, :prepare_binds_for_database, :cacheable_query, :column_name_for_operation,
+      :prepared_statements, :transaction_state, :create_table, to: :select_connection
+
+    def execute(sql, name = nil)
+      conn = select_connection
+      clean_connection_proxy
+      conn.execute(sql, name)
+    end
+
+    def delete(arel, name = nil, binds = [])
+      conn = select_connection
+      clean_connection_proxy
+      conn.delete(arel, name, binds)
+    end
+
+    def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
+      conn = select_connection
+      clean_connection_proxy
+      conn.insert(arel, name, pk, id_value, sequence_name, binds)
+    end
+
+    def update(arel, name = nil, binds = [])
+      conn = select_connection
+      clean_connection_proxy
+      conn.update(arel, name, binds)
+    end
 
     # Rails 3.1 sets automatic_reconnect to false when it removes
     # connection pool.  Octopus can potentially retain a reference to a closed


### PR DESCRIPTION
Hi Folks,

This PR focus on removing (or at least deprecating) the method_missing from Octopus::Proxy. This is a move to improve the stability and increase the predictability of the gem's behavior. Hopefully this will be a step to have less bugs in the future.

Thiago