### PR TITLE
Add establish connection to the alias hijacking.

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -109,6 +109,9 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
           alias_method :connected_without_octopus?, :connected?
           alias_method :connected?, :connected_with_octopus?
 
+          alias_method :establish_connection_without_octopus, :establish_connection
+          alias_method :establish_connection, :establish_connection_with_octopus
+
           def table_name=(value = nil)
             self.custom_octopus_table_name = true
             super
@@ -184,9 +187,9 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
         set_table_name_without_octopus(value, &block)
       end
 
-      def octopus_establish_connection(spec = ENV['DATABASE_URL'])
+      def establish_connection_with_octopus(spec = ENV['DATABASE_URL'])
         self.custom_octopus_connection = true if spec
-        establish_connection(spec)
+        establish_connection_without_octopus(spec)
       end
 
       def octopus_set_table_name(value = nil)


### PR DESCRIPTION
This fixes https://github.com/thiagopradi/octopus/issues/426
Kudos to @camertron! \o/

### Proposed solution:
Alias the `establish_connection` method to explicitly and return an `establish_connection_without_octopus` connection.

This will cause `establish_connection configuration_without_database` to return a `MySQL2::Adapter` class instead of a `Octopus::Proxy` class, from which we can successfully call `connection.create_database` and bypass `Octopus::Proxy#method_missing`