### PR TITLE
Supoprt parallel migration

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 4.0.0'
   s.add_dependency 'activesupport', '>= 4.0.0'
+  s.add_dependency 'parallel'
 
   s.add_development_dependency 'appraisal', '>= 0.3.8'
   s.add_development_dependency 'mysql2', '~> 0.3.18'

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'octopus/slave_group'
 require 'octopus/load_balancing/round_robin'
+require 'parallel'
 
 module Octopus
   class Proxy
@@ -90,6 +91,14 @@ module Octopus
     def send_queries_to_multiple_shards(shards, &block)
       shards.map do |shard|
         run_queries_on_shard(shard, &block)
+      end
+    end
+
+    def send_queries_to_multiple_shards_in_parallel(shards, &block)
+      Parallel.map(shards, in_threads: shards.count) do |shard|
+        connection_pool.with_connection do
+          run_queries_on_shard(shard, &block)
+        end
       end
     end
 

--- a/lib/tasks/octopus.rake
+++ b/lib/tasks/octopus.rake
@@ -14,3 +14,16 @@ namespace :octopus do
     end
   end
 end
+
+namespace :db do
+  namespace :migrate do
+    desc 'Run migration for all shards in parallel'
+    task :parallel => :environment do
+      abort('Octopus is not enabled for this environment') unless Octopus.enabled?
+
+      ActiveRecord::Migrator.enable_parallel_migration
+
+      Rake::Task["db:migrate"].invoke
+    end
+  end
+end

--- a/spec/migrations/16_add_column_to_user_on_shards.rb
+++ b/spec/migrations/16_add_column_to_user_on_shards.rb
@@ -1,0 +1,7 @@
+class AddColumnToUserOnShards < BaseOctopusMigrationClass
+  using(:europe, :brazil, :canada, :russia, :master)
+
+  def change
+    add_column :users, :age, :integer
+  end
+end

--- a/spec/migrations/17_add_column_to_user_on_shards_in_old_style.rb
+++ b/spec/migrations/17_add_column_to_user_on_shards_in_old_style.rb
@@ -1,0 +1,11 @@
+class AddColumnToUserOnShardsInOldStyle < BaseOctopusMigrationClass
+  using(:europe, :brazil, :canada, :russia, :master)
+
+  def self.up
+    add_column :users, :title, :string
+  end
+
+  def self.down
+    remove_column :users, :title
+  end
+end

--- a/spec/octopus/migration_spec.rb
+++ b/spec/octopus/migration_spec.rb
@@ -112,4 +112,27 @@ describe Octopus::Migration do
     end
   end
 
+  it 'should run the migrations in parallel on the shards' do
+    OctopusHelper.using_environment :not_entire_sharded do
+      OctopusHelper.enable_parallel_migration do
+        OctopusHelper.migrating_to_version 16 do
+          [:master, :europe, :canada, :brazil, :russia].each do |sym|
+            expect(Octopus.using(sym) { ActiveRecord::Migrator.get_all_versions }).to include(16)
+          end
+        end
+      end
+    end
+  end
+
+  it 'should run the old-style migrations in parallel on the shards' do
+    OctopusHelper.using_environment :not_entire_sharded do
+      OctopusHelper.enable_parallel_migration do
+        OctopusHelper.migrating_to_version 17 do
+          [:master, :europe, :canada, :brazil, :russia].each do |sym|
+            expect(Octopus.using(sym) { ActiveRecord::Migrator.get_all_versions }).to include(17)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/support/octopus_helper.rb
+++ b/spec/support/octopus_helper.rb
@@ -51,4 +51,11 @@ module OctopusHelper
     Octopus.instance_variable_set(:@config, nil)
     Octopus.stub(:env).and_return(env)
   end
+
+  def self.enable_parallel_migration
+    ActiveRecord::Migrator.enable_parallel_migration
+    yield
+  ensure
+    ActiveRecord::Migrator.disable_parallel_migration
+  end
 end


### PR DESCRIPTION
Parallel migration is useful for time-consuming migrations such as adding columns to tables with huge rows.

This adds the parallel migration support to octopus, and the rake task for it:

```
    rake db:migrate:parallel
````

Note that the shards must not contain the same database; otherwise the parallel migration will fail by advisary-lock in Rails 5.