### PR TITLE
Rails 5.1 fix -- has_and_belongs_to_many

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -110,6 +110,10 @@ module Octopus
     ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR == 1
   end
 
+  def self.atleast_rails51?
+    ActiveRecord::VERSION::MAJOR > 5 || (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1)
+  end
+
   attr_writer :logger
 
   def self.logger

--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -44,7 +44,7 @@ module Octopus
       super
     end
 
-    def has_and_belongs_to_many(association_id, scope = nil, options = {}, &extension)
+    def has_and_belongs_to_many(association_id, scope = nil, **options, &extension)
       if options == {} && scope.is_a?(Hash)
         default_octopus_opts(scope)
       else
@@ -53,7 +53,7 @@ module Octopus
       super
     end
 
-    def default_octopus_opts(options)
+    def default_octopus_opts(**options)
       options[:before_add] = [ :connection_on_association=, options[:before_add] ].compact.flatten
       options[:before_remove] = [ :connection_on_association=, options[:before_remove] ].compact.flatten
     end

--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -45,11 +45,7 @@ module Octopus
     end
 
     def has_and_belongs_to_many(association_id, scope = nil, options = {}, &extension)
-      if options == {} && scope.is_a?(Hash)
-        default_octopus_opts(scope)
-      else
-        default_octopus_opts(options)
-      end
+      assign_octopus_opts(scope, options)
       super
     end
 
@@ -58,19 +54,18 @@ module Octopus
       options[:before_remove] = [ :connection_on_association=, options[:before_remove] ].compact.flatten
     end
 
+    def assign_octopus_opts(scope, options)
+      if options == {} && scope.is_a?(Hash)
+        default_octopus_opts(scope)
+      else
+        default_octopus_opts(options)
+      end
+    end
+
     if Octopus.atleast_rails51?
       def has_and_belongs_to_many(association_id, scope = nil, **options, &extension)
-        if options == {} && scope.is_a?(Hash)
-          default_octopus_opts(scope)
-        else
-          default_octopus_opts(options)
-        end
+        assign_octopus_opts(scope, options)
         super
-      end
-
-      def default_octopus_opts(**options)
-        options[:before_add] = [ :connection_on_association=, options[:before_add] ].compact.flatten
-        options[:before_remove] = [ :connection_on_association=, options[:before_remove] ].compact.flatten
       end
     end
   end

--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -44,7 +44,7 @@ module Octopus
       super
     end
 
-    def has_and_belongs_to_many(association_id, scope = nil, **options, &extension)
+    def has_and_belongs_to_many(association_id, scope = nil, options = {}, &extension)
       if options == {} && scope.is_a?(Hash)
         default_octopus_opts(scope)
       else
@@ -53,9 +53,25 @@ module Octopus
       super
     end
 
-    def default_octopus_opts(**options)
+    def default_octopus_opts(options)
       options[:before_add] = [ :connection_on_association=, options[:before_add] ].compact.flatten
       options[:before_remove] = [ :connection_on_association=, options[:before_remove] ].compact.flatten
+    end
+
+    if Octopus.atleast_rails51?
+      def has_and_belongs_to_many(association_id, scope = nil, **options, &extension)
+        if options == {} && scope.is_a?(Hash)
+          default_octopus_opts(scope)
+        else
+          default_octopus_opts(options)
+        end
+        super
+      end
+
+      def default_octopus_opts(**options)
+        options[:before_add] = [ :connection_on_association=, options[:before_add] ].compact.flatten
+        options[:before_remove] = [ :connection_on_association=, options[:before_remove] ].compact.flatten
+      end
     end
   end
 end

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -52,11 +52,11 @@ class Computer < ActiveRecord::Base
 end
 
 class Role < ActiveRecord::Base
-  has_and_belongs_to_many :permissions, required: false
+  has_and_belongs_to_many :permissions
 end
 
 class Permission < ActiveRecord::Base
-  has_and_belongs_to_many :roles, required: false
+  has_and_belongs_to_many :roles
 end
 
 class Assignment < ActiveRecord::Base

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -52,11 +52,11 @@ class Computer < ActiveRecord::Base
 end
 
 class Role < ActiveRecord::Base
-  has_and_belongs_to_many :permissions
+  has_and_belongs_to_many :permissions, required: false
 end
 
 class Permission < ActiveRecord::Base
-  has_and_belongs_to_many :roles
+  has_and_belongs_to_many :roles, required: false
 end
 
 class Assignment < ActiveRecord::Base


### PR DESCRIPTION
Summary
-----

This PR fixes a missed change when adding Octopus support for Rails 5.1. In 5.1, the options argument in the method `has_and_belongs_to_many` was changed from `options = {}` to `**options`.  Due to the argument inconsistency, supplied options to `has_and_belongs_to_many`  are ignored 

@thiagopradi Please review, test and merge. This fixes my integration issues when using Rails 5.1.