### PR TITLE
Use the MYSQL_USER environment variable in all the specs

### DIFF
--- a/spec/octopus/octopus_spec.rb
+++ b/spec/octopus/octopus_spec.rb
@@ -40,7 +40,7 @@ describe Octopus, :shards => [] do
       expect { User.using(:crazy_shard).create!(:name => 'Joaquim') }.to raise_error(RuntimeError)
 
       Octopus.setup do |config|
-        config.shards = { :crazy_shard => { :adapter => 'mysql2', :database => 'octopus_shard_5', :username => 'root', :password => '' } }
+        config.shards = { :crazy_shard => { :adapter => 'mysql2', :database => 'octopus_shard_5', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '' } }
       end
 
       expect { User.using(:crazy_shard).create!(:name => 'Joaquim')  }.not_to raise_error

--- a/spec/octopus/proxy_spec.rb
+++ b/spec/octopus/proxy_spec.rb
@@ -30,7 +30,7 @@ describe Octopus::Proxy do
       config = proxy.config
       expect(config[:adapter]).to eq('mysql2')
       expect(config[:database]).to eq('octopus_shard_1')
-      expect(config[:username]).to eq('root')
+      expect(config[:username]).to eq("#{ENV['MYSQL_USER'] || 'root'}")
     end
 
     unless Octopus.rails50? || Octopus.rails51?

--- a/spec/support/database_connection.rb
+++ b/spec/support/database_connection.rb
@@ -1,4 +1,4 @@
 require 'logger'
 
-ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'octopus_shard_1', :username => 'root', :password => '')
+ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'octopus_shard_1', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '')
 ActiveRecord::Base.logger = Logger.new(File.open('database.log', 'a'))

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -28,7 +28,7 @@ end
 # This class sets its own connection
 class CustomConnection < ActiveRecord::Base
   self.table_name = 'custom'
-  octopus_establish_connection(:adapter => 'mysql2', :database => 'octopus_shard_2', :username => 'root', :password => '')
+  octopus_establish_connection(:adapter => 'mysql2', :database => 'octopus_shard_2', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '')
 end
 
 # This items belongs to a client


### PR DESCRIPTION
I tried to use a MySQL user (with no password :-() for the Octopus
specs, however, I need to make these adjustments to get a green build.

I am sure there is a better way to set up the configuration file, but this now
fixes the immediate problem.