### PR TITLE
Don't alter underlying AR relations when chaining

### DIFF
--- a/lib/octopus/scope_proxy.rb
+++ b/lib/octopus/scope_proxy.rb
@@ -46,8 +46,7 @@ module Octopus
     def method_missing(method, *args, &block)
       result = run_on_shard { @klass.send(method, *args, &block) }
       if result.respond_to?(:all)
-        @klass = result
-        return self
+        return ::Octopus::ScopeProxy.new(current_shard, result)
       end
 
       if result.respond_to?(:current_shard)

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -28,6 +28,28 @@ describe Octopus::RelationProxy do
       expect(not_relation.current_shard).to eq(@relation.current_shard)
     end
 
+    context 'when a new relation is constructed from the original relation' do
+      context 'and a where(...) is used' do
+        it 'does not tamper with the original relation' do
+          relation = Item.using(:canada).where(id: 1)
+          original_sql = relation.to_sql
+          new_relation = relation.where(id: 2)
+          expect(relation.to_sql).to eq(original_sql)
+          puts new_relation.to_sql
+        end
+      end
+
+      context 'and a where.not(...) is used' do
+        it 'does not tamper with the original relation' do
+          relation = Item.using(:canada).where(id: 1)
+          original_sql = relation.to_sql
+          new_relation = relation.where.not(id: 2)
+          expect(relation.to_sql).to eq(original_sql)
+          puts new_relation.to_sql
+        end
+      end
+    end
+
     context 'when comparing to other Relation objects' do
       before :each do
         @relation.reset

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -35,7 +35,6 @@ describe Octopus::RelationProxy do
           original_sql = relation.to_sql
           new_relation = relation.where(id: 2)
           expect(relation.to_sql).to eq(original_sql)
-          puts new_relation.to_sql
         end
       end
 
@@ -45,7 +44,6 @@ describe Octopus::RelationProxy do
           original_sql = relation.to_sql
           new_relation = relation.where.not(id: 2)
           expect(relation.to_sql).to eq(original_sql)
-          puts new_relation.to_sql
         end
       end
     end


### PR DESCRIPTION
We've been bitten a few times by this bug.

To demonstrate:

```
relation = Item.using(:canada).where(id: 1)
puts relation.to_sql
=> SELECT `items`.* FROM `items` WHERE `items`.`id` = 1

new_relation = relation.where(id: 2)
puts relation.to_sql
=> SELECT `items`.* FROM `items` WHERE `items`.`id` = 1 AND `items`.`id` = 2
```

We don't expect `relation` to have changed.