### PR TITLE
Add octopus_disable! feature

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -203,6 +203,17 @@ CustomConnectedModel.using(:some_other_shard).first
 
 This can be useful if you have a model that lives in a separate database and would like to add sharding or replication to it. For other use cases, you may be better off with <a href="https://github.com/thiagopradi/octopus/wiki/Slave-Groups">slave groups</a>.
 
+### octopus_disable!
+If you'd like to completely disable octopus for specific model you can use `octopus_disable!`:
+
+```ruby
+class ModelWithoutOctopus
+  octopus_disable!
+end
+```
+
+As a result any query will use Rails-managed connection pool
+
 ## Contributing with Octopus
 Contributors are welcome! To run the test suite, you need mysql, postgresql and sqlite3 installed. This is what you need to setup your Octopus development environment:
 

--- a/Rakefile
+++ b/Rakefile
@@ -164,6 +164,10 @@ namespace :db do
           u.string :name
         end
       end
+
+      BlankModel.using(shard_symbol).connection.create_table(:disabled_models) do |u|
+        u.integer :name
+      end
     end
   end
 

--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'appraisal', '>= 0.3.8'
   s.add_development_dependency 'mysql2', '~> 0.3.18'
-  s.add_development_dependency 'pg', '>= 0.11.0'
+  s.add_development_dependency 'pg', '~> 0.18'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'
   s.add_development_dependency 'rubocop'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -113,6 +113,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
 
         class << self
           attr_accessor :custom_octopus_table_name
+          attr_accessor :octopus_disabled
 
           alias_method :connection_without_octopus, :connection
           alias_method :connection, :connection_with_octopus
@@ -143,7 +144,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
       end
 
       def should_use_normal_connection?
-        if !Octopus.enabled?
+        if !Octopus.enabled? || octopus_disabled
           true
         elsif custom_octopus_connection
           !connection_proxy.block || !allowed_shard?(connection_proxy.current_shard)
@@ -212,6 +213,10 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
       def octopus_set_table_name(value = nil)
         ActiveSupport::Deprecation.warn 'Calling `octopus_set_table_name` is deprecated and will be removed in Octopus 1.0.', caller
         set_table_name(value)
+      end
+
+      def octopus_disable!
+        self.octopus_disabled = true
       end
     end
   end

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -751,4 +751,14 @@ describe Octopus::Model do
       end
     end
   end
+
+  describe "#octopus_disable! method" do
+    it "should return OctopusProxy if octopus enabled for model" do
+      expect(User.connection.class).to eq(Octopus::Proxy)
+    end
+
+    it "should return ActiveRecord connection instance" do
+      expect(DisabledModel.connection.class).to eq(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+    end
+  end
 end

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -116,3 +116,7 @@ class Skill < ActiveRecord::Base
   validates_presence_of :mmorpg_player
   validates :name, :uniqueness => { :scope => :mmorpg_player_id }
 end
+
+class DisabledModel < ActiveRecord::Base
+  octopus_disable!
+end


### PR DESCRIPTION
For some models it maybe useful to using rails default behaviour.
I.e. [blazer gem](https://github.com/ankane/blazer/blob/master/app/models/blazer/connection.rb#L2) use ActiveRecord models to [establish connection](https://github.com/ankane/blazer/blob/master/lib/blazer/adapters/sql_adapter.rb#L14) to some different database.
So disable octopus for specific model is a one of possible solution for this kind of problems.
