### PR TITLE
Add RelationProxy support Enumerator block in Rails 5

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -22,7 +22,11 @@ module Octopus
 
     def method_missing(method, *args, &block)
       if block
-        @ar_relation.public_send(method, *args, &block)
+        if !::Object.method_defined?(method) && ::Enumerator.method_defined?(method)
+          run_on_shard { @ar_relation.public_send(method, *args, &block) }
+        else
+          @ar_relation.public_send(method, *args, &block)
+        end
       else
         run_on_shard do
           if method == :load_records


### PR DESCRIPTION
As issue #478, the load records behavior is changed in Rails 5. To ensure our query can run on the correct shard, we have to handle the block when we got Enumerator's method.