### PR TITLE
Fix association shard tracking combined with enum method chain in Rails5

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -25,7 +25,8 @@ module Octopus
     end + [:each, :map, :sum, :index_by] # redefined methods in ActiveRecord that should run_on_shard
 
     def method_missing(method, *args, &block)
-      if ENUM_METHODS.include? method
+      # `find { ... }` should be sent to records on the shard, `find(id)` should be sent to relation
+      if ENUM_METHODS.include?(method) || block && method == :find
         run_on_shard { @ar_relation.to_a }.public_send(method, *args, &block)
       elsif block
         @ar_relation.public_send(method, *args, &block)

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -22,7 +22,7 @@ module Octopus
 
     ENUM_METHODS = (::Enumerable.instance_methods - ::Object.instance_methods).reject do |m|
       ::ActiveRecord::Relation.instance_method(m).source_location rescue nil
-    end + [:each, :map]
+    end + [:each, :map, :sum, :index_by] # redefined methods in ActiveRecord that should run_on_shard
 
     def method_missing(method, *args, &block)
       if ENUM_METHODS.include? method

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -25,7 +25,7 @@ module Octopus
       ::ActiveRecord::Relation.instance_method(m).source_location rescue nil
     end + [:each, :map, :sum, :index_by]
     # `find { ... }` etc. should run_on_shard, `find(id)` should be sent to relation
-    ENUM_WITH_BLOCK_METHODS = [:find, :select]
+    ENUM_WITH_BLOCK_METHODS = [:find, :select, :none?, :any?, :one?, :many?]
 
     def method_missing(method, *args, &block)
       if ENUM_METHODS.include?(method) || block && ENUM_WITH_BLOCK_METHODS.include?(method)

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -20,8 +20,14 @@ module Octopus
       method_missing(:respond_to?, *args)
     end
 
+    ENUM_METHODS = (::Enumerable.instance_methods - ::Object.instance_methods).reject do |m|
+      ::ActiveRecord::Relation.instance_method(m).source_location rescue nil
+    end + [:each, :map]
+
     def method_missing(method, *args, &block)
-      if block
+      if ENUM_METHODS.include? method
+        run_on_shard { @ar_relation.to_a }.public_send(method, *args, &block)
+      elsif block
         @ar_relation.public_send(method, *args, &block)
       else
         run_on_shard do

--- a/lib/octopus/scope_proxy.rb
+++ b/lib/octopus/scope_proxy.rb
@@ -44,7 +44,7 @@ module Octopus
     end
 
     def method_missing(method, *args, &block)
-      result = run_on_shard { @klass.send(method, *args, &block) }
+      result = run_on_shard { @klass.__send__(method, *args, &block) }
       if result.respond_to?(:all)
         return ::Octopus::ScopeProxy.new(current_shard, result)
       end

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -196,6 +196,35 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@permission_brazil_2.roles.first).to be_nil
       end
 
+      it 'where' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1')).to eq([role])
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1')).to be_empty
+      end
+
+      it 'map' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.map(&:id)).to eq([role.id])
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.map(&:id)).to be_empty
+      end
+
+      it 'where + map' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').map(&:id)).to eq([role.id])
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').map(&:id)).to be_empty
+      end
+
+      # each_with_index is not listed in active_record/relation/delegation.rb
+      it 'where + each_with_index + map (enum method chain)' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to eq([[role.id, 0]])
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
+      end
+
       it 'exists?' do
         role = @permission_brazil_2.roles.create(:name => 'Builded Role')
         expect(@permission_brazil_2.roles.exists?(role.id)).to be true
@@ -348,6 +377,34 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@new_brazil_programmer.projects.first).to eq(role)
         @new_brazil_programmer.projects.destroy_all
         expect(@new_brazil_programmer.projects.first).to be_nil
+      end
+
+      it 'where' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1')).to eq([role])
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1')).to be_empty
+      end
+
+      it 'map' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.map(&:id)).to eq([role.id])
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.map(&:id)).to be_empty
+      end
+
+      it 'where + map' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').map(&:id)).to eq([role.id])
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').map(&:id)).to be_empty
+      end
+
+      it 'where + each_with_index + map (enum method chain)' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').each_with_index.map { |r, i| [r.id, i] }).to eq([[role.id, 0]])
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').each_with_index.map { |r, i| [r.id, i] }).to be_empty
       end
 
       it 'exists?' do
@@ -545,6 +602,30 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.items.first).to be_nil
       end
 
+      it 'where' do
+        expect(@brazil_client.items.where('1=1')).to eq([@item_brazil])
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1')).to be_empty
+      end
+
+      it 'map' do
+        expect(@brazil_client.items.map(&:id)).to eq([@item_brazil.id])
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.map(&:id)).to be_empty
+      end
+
+      it 'where + map' do
+        expect(@brazil_client.items.where('1=1').map(&:id)).to eq([@item_brazil.id])
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').map(&:id)).to be_empty
+      end
+
+      it 'where + each_with_index + map (enum method chain)' do
+        expect(@brazil_client.items.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to eq([[@item_brazil.id, 0]])
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
+      end
+
       it 'exists?' do
         expect(@brazil_client.items.exists?(@item_brazil.id)).to be true
         @brazil_client.items.destroy_all
@@ -693,6 +774,30 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.first).to eq(@comment_brazil)
         @brazil_client.comments.destroy_all
         expect(@brazil_client.comments.first).to be_nil
+      end
+
+      it 'where' do
+        expect(@brazil_client.comments.where('1=1')).to eq([@comment_brazil])
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1')).to be_empty
+      end
+
+      it 'map' do
+        expect(@brazil_client.comments.map(&:id)).to eq([@comment_brazil.id])
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.map(&:id)).to be_empty
+      end
+
+      it 'where + map' do
+        expect(@brazil_client.comments.where('1=1').map(&:id)).to eq([@comment_brazil.id])
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').map(&:id)).to be_empty
+      end
+
+      it 'where + each_with_index + map (enum method chain)' do
+        expect(@brazil_client.comments.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to eq([[@comment_brazil.id, 0]])
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
       end
 
       it 'exists?' do

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -268,6 +268,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@permission_brazil_2.roles.where('1=1').select { |r| r.id == role.id }).to be_empty
       end
 
+      it 'where + any?' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').any?).to be true
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').any?).to be false
+      end
+
+      it 'where + any? with block' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').any? { |r| r.id == role.id }).to be true
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').any? { |r| r.id == role.id }).to be false
+      end
+
       it 'exists?' do
         role = @permission_brazil_2.roles.create(:name => 'Builded Role')
         expect(@permission_brazil_2.roles.exists?(role.id)).to be true
@@ -490,6 +504,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@new_brazil_programmer.projects.where('1=1').select { |r| r.id == role.id }).to eq([role])
         @new_brazil_programmer.projects.destroy_all
         expect(@new_brazil_programmer.projects.where('1=1').select { |r| r.id == role.id }).to be_empty
+      end
+
+      it 'where + any?' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').any?).to be true
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').any?).to be false
+      end
+
+      it 'where + any? with block' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').any? { |r| r.id == role.id }).to be true
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').any? { |r| r.id == role.id }).to be false
       end
 
       it 'exists?' do
@@ -747,6 +775,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.items.where('1=1').select { |i| i.id == @item_brazil.id }).to be_empty
       end
 
+      it 'where + any?' do
+        expect(@brazil_client.items.where('1=1').any?).to be true
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').any?).to be false
+      end
+
+      it 'where + any? with block' do
+        expect(@brazil_client.items.where('1=1').any? { |i| i.id == @item_brazil.id }).to be true
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').any? { |i| i.id == @item_brazil.id }).to be false
+      end
+
       it 'exists?' do
         expect(@brazil_client.items.exists?(@item_brazil.id)).to be true
         @brazil_client.items.destroy_all
@@ -955,6 +995,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.where('1=1').select { |c| c.id == @comment_brazil.id }).to eq([@comment_brazil])
         @brazil_client.comments.destroy_all
         expect(@brazil_client.comments.where('1=1').select { |c| c.id == @comment_brazil.id }).to be_empty
+      end
+
+      it 'where + any?' do
+        expect(@brazil_client.comments.where('1=1').any?).to be true
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').any?).to be false
+      end
+
+      it 'where + any? with block' do
+        expect(@brazil_client.comments.where('1=1').any? { |c| c.id == @comment_brazil.id }).to be true
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').any? { |c| c.id == @comment_brazil.id }).to be false
       end
 
       it 'exists?' do

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -240,6 +240,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@permission_brazil_2.roles.where('1=1').index_by(&:id)).to be_empty
       end
 
+      it 'where + find' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').find([role.id])).to eq([role])
+        @permission_brazil_2.roles.destroy_all
+        expect { @permission_brazil_2.roles.where('1=1').find([role.id]) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'where + find with block' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').find { |r| r.id == role.id }).to eq(role)
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').find { |r| r.id == role.id }).to be_nil
+      end
+
       it 'exists?' do
         role = @permission_brazil_2.roles.create(:name => 'Builded Role')
         expect(@permission_brazil_2.roles.exists?(role.id)).to be true
@@ -434,6 +448,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@new_brazil_programmer.projects.where('1=1').index_by(&:id)).to eq(role.id => role)
         @new_brazil_programmer.projects.destroy_all
         expect(@new_brazil_programmer.projects.where('1=1').index_by(&:id)).to be_empty
+      end
+
+      it 'where + find' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').find(role.id)).to eq(role)
+        @new_brazil_programmer.projects.destroy_all
+        expect { @new_brazil_programmer.projects.where('1=1').find(role.id) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'where + find with block' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').find { |r| r.id == role.id }).to eq(role)
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').find { |r| r.id == role.id }).to be_nil
       end
 
       it 'exists?' do
@@ -667,6 +695,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.items.where('1=1').index_by(&:id)).to be_empty
       end
 
+      it 'where + find' do
+        expect(@brazil_client.items.where('1=1').find(@item_brazil.id)).to eq(@item_brazil)
+        @brazil_client.items.destroy_all
+        expect { @brazil_client.items.where('1=1').find(@item_brazil.id) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'where + find with block' do
+        expect(@brazil_client.items.where('1=1').find { |i| i.id == @item_brazil.id }).to eq(@item_brazil)
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').find { |i| i.id == @item_brazil.id }).to be_nil
+      end
+
       it 'exists?' do
         expect(@brazil_client.items.exists?(@item_brazil.id)).to be true
         @brazil_client.items.destroy_all
@@ -851,6 +891,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.where('1=1').index_by(&:id)).to eq(@comment_brazil.id => @comment_brazil)
         @brazil_client.comments.destroy_all
         expect(@brazil_client.comments.where('1=1').index_by(&:id)).to be_empty
+      end
+
+      it 'where + find' do
+        expect(@brazil_client.comments.where('1=1').find(@comment_brazil.id)).to eq(@comment_brazil)
+        @brazil_client.comments.destroy_all
+        expect { @brazil_client.comments.where('1=1').find(@comment_brazil.id) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'where + find with block' do
+        expect(@brazil_client.comments.where('1=1').find { |c| c.id == @comment_brazil.id }).to eq(@comment_brazil)
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').find { |c| c.id == @comment_brazil.id }).to be_nil
       end
 
       it 'exists?' do

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -254,6 +254,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@permission_brazil_2.roles.where('1=1').find { |r| r.id == role.id }).to be_nil
       end
 
+      it 'where + select' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').select(:name).first.name).to eq(role.name)
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').select(:name)).to be_empty
+      end
+
+      it 'where + select with block' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').select { |r| r.id == role.id }).to eq([role])
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').select { |r| r.id == role.id }).to be_empty
+      end
+
       it 'exists?' do
         role = @permission_brazil_2.roles.create(:name => 'Builded Role')
         expect(@permission_brazil_2.roles.exists?(role.id)).to be true
@@ -462,6 +476,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@new_brazil_programmer.projects.where('1=1').find { |r| r.id == role.id }).to eq(role)
         @new_brazil_programmer.projects.destroy_all
         expect(@new_brazil_programmer.projects.where('1=1').find { |r| r.id == role.id }).to be_nil
+      end
+
+      it 'where + select' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').select(:name).first.name).to eq(role.name)
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').select(:name)).to be_empty
+      end
+
+      it 'where + select with block' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').select { |r| r.id == role.id }).to eq([role])
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').select { |r| r.id == role.id }).to be_empty
       end
 
       it 'exists?' do
@@ -707,6 +735,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.items.where('1=1').find { |i| i.id == @item_brazil.id }).to be_nil
       end
 
+      it 'where + select' do
+        expect(@brazil_client.items.where('1=1').select(:name).first.name).to eq(@item_brazil.name)
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').select(:name)).to be_empty
+      end
+
+      it 'where + select with block' do
+        expect(@brazil_client.items.where('1=1').select { |i| i.id == @item_brazil.id }).to eq([@item_brazil])
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').select { |i| i.id == @item_brazil.id }).to be_empty
+      end
+
       it 'exists?' do
         expect(@brazil_client.items.exists?(@item_brazil.id)).to be true
         @brazil_client.items.destroy_all
@@ -903,6 +943,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.where('1=1').find { |c| c.id == @comment_brazil.id }).to eq(@comment_brazil)
         @brazil_client.comments.destroy_all
         expect(@brazil_client.comments.where('1=1').find { |c| c.id == @comment_brazil.id }).to be_nil
+      end
+
+      it 'where + select' do
+        expect(@brazil_client.comments.where('1=1').select(:name).first.name).to eq(@comment_brazil.name)
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').select(:name)).to be_empty
+      end
+
+      it 'where + select with block' do
+        expect(@brazil_client.comments.where('1=1').select { |c| c.id == @comment_brazil.id }).to eq([@comment_brazil])
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').select { |c| c.id == @comment_brazil.id }).to be_empty
       end
 
       it 'exists?' do

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -225,6 +225,21 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@permission_brazil_2.roles.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
       end
 
+      # sum & index_by is specialized in active_support/core_ext/enumerable.rb
+      it 'where + sum' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').sum(&:id)).to eq(role.id)
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').sum(&:id)).to eq(0)
+      end
+
+      it 'where + index_by' do
+        role = @permission_brazil_2.roles.create(:name => 'Builded Role')
+        expect(@permission_brazil_2.roles.where('1=1').index_by(&:id)).to eq(role.id => role)
+        @permission_brazil_2.roles.destroy_all
+        expect(@permission_brazil_2.roles.where('1=1').index_by(&:id)).to be_empty
+      end
+
       it 'exists?' do
         role = @permission_brazil_2.roles.create(:name => 'Builded Role')
         expect(@permission_brazil_2.roles.exists?(role.id)).to be true
@@ -405,6 +420,20 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@new_brazil_programmer.projects.where('1=1').each_with_index.map { |r, i| [r.id, i] }).to eq([[role.id, 0]])
         @new_brazil_programmer.projects.destroy_all
         expect(@new_brazil_programmer.projects.where('1=1').each_with_index.map { |r, i| [r.id, i] }).to be_empty
+      end
+
+      it 'where + sum' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').sum(&:id)).to eq(role.id)
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').sum(&:id)).to eq(0)
+      end
+
+      it 'where + index_by' do
+        role = @new_brazil_programmer.projects.create(:name => 'New VB App :-/')
+        expect(@new_brazil_programmer.projects.where('1=1').index_by(&:id)).to eq(role.id => role)
+        @new_brazil_programmer.projects.destroy_all
+        expect(@new_brazil_programmer.projects.where('1=1').index_by(&:id)).to be_empty
       end
 
       it 'exists?' do
@@ -626,6 +655,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.items.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
       end
 
+      it 'where + sum' do
+        expect(@brazil_client.items.where('1=1').sum(&:id)).to eq(@item_brazil.id)
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').sum(&:id)).to eq(0)
+      end
+
+      it 'where + index_by' do
+        expect(@brazil_client.items.where('1=1').index_by(&:id)).to eq(@item_brazil.id => @item_brazil)
+        @brazil_client.items.destroy_all
+        expect(@brazil_client.items.where('1=1').index_by(&:id)).to be_empty
+      end
+
       it 'exists?' do
         expect(@brazil_client.items.exists?(@item_brazil.id)).to be true
         @brazil_client.items.destroy_all
@@ -798,6 +839,18 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to eq([[@comment_brazil.id, 0]])
         @brazil_client.comments.destroy_all
         expect(@brazil_client.comments.where('1=1').each_with_index.map { |r, i| [r.id, i]}).to be_empty
+      end
+
+      it 'where + sum' do
+        expect(@brazil_client.comments.where('1=1').sum(&:id)).to eq(@comment_brazil.id)
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').sum(&:id)).to eq(0)
+      end
+
+      it 'where + index_by' do
+        expect(@brazil_client.comments.where('1=1').index_by(&:id)).to eq(@comment_brazil.id => @comment_brazil)
+        @brazil_client.comments.destroy_all
+        expect(@brazil_client.comments.where('1=1').index_by(&:id)).to be_empty
       end
 
       it 'exists?' do

--- a/spec/octopus/scope_proxy_spec.rb
+++ b/spec/octopus/scope_proxy_spec.rb
@@ -73,4 +73,25 @@ describe Octopus::ScopeProxy do
       expect(cloned_object.object_id).not_to eq(user.object_id)
     end
   end
+
+  context 'When iterated with Enumerable methods' do
+    before(:each) do
+      User.using(:brazil).create!(:name => 'Evan', :number => 1)
+      User.using(:brazil).create!(:name => 'Evan', :number => 2)
+      User.using(:brazil).create!(:name => 'Evan', :number => 3)
+      @evans = User.using(:brazil).where(:name => 'Evan')
+    end
+
+    it 'allows each method' do
+      expect(@evans.each.count).to eq(3)
+    end
+
+    it 'allows each_with_index method' do
+      expect(@evans.each_with_index.to_a.flatten.count).to eq(6)
+    end
+
+    it 'allows map method' do
+      expect(@evans.map(&:number)).to eq([1, 2, 3])
+    end
+  end
 end


### PR DESCRIPTION
Currently, when Enumerable methods that takes block are called for
relations scoped from a shard, ActiveRecord::Relation object is
populated out of the shard, so the records from the master are used.

e.g.:
```
    User.using(:brazil).first.projects.where(id: ids).map(&:name)
```
will execute the query on the `:master` shard, instead of `:brazil`.

This patch lists up the Enumerable methods that are not redefined
by ActiveRecord classes, and redirect them to objects taken from
the correct shards.

This will resolve #478.