### PR TITLE
Fix query cache enable/disable methods proxy on Rails5.x

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -194,6 +194,7 @@ require 'octopus/log_subscriber'
 require 'octopus/abstract_adapter'
 require 'octopus/singular_association'
 require 'octopus/finder_methods'
+require 'octopus/query_cache_for_shards' unless Octopus.rails4?
 
 require 'octopus/railtie' if defined?(::Rails::Railtie)
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -139,13 +139,15 @@ module Octopus
       shards[current_shard]
     end
 
-    def enable_query_cache!
-      clear_query_cache
-      with_each_healthy_shard { |v| v.connected? && safe_connection(v).enable_query_cache! }
-    end
+    if Octopus.rails4?
+      def enable_query_cache!
+        clear_query_cache
+        with_each_healthy_shard { |v| v.connected? && safe_connection(v).enable_query_cache! }
+      end
 
-    def disable_query_cache!
-      with_each_healthy_shard { |v| v.connected? && safe_connection(v).disable_query_cache! }
+      def disable_query_cache!
+        with_each_healthy_shard { |v| v.connected? && safe_connection(v).disable_query_cache! }
+      end
     end
 
     def clear_query_cache

--- a/lib/octopus/query_cache_for_shards.rb
+++ b/lib/octopus/query_cache_for_shards.rb
@@ -1,0 +1,25 @@
+# query cache methods are moved to ConnectionPool for Rails >= 5.0
+module Octopus
+  module ConnectionPool
+    module QueryCacheForShards
+      %i(enable_query_cache! disable_query_cache!).each do |method|
+        define_method(method) do
+          shards = ActiveRecord::Base.connection.shards
+          if shards["master"] == self
+            shards.each do |shard_name, v|
+              if shard_name == "master"
+                super()
+              else
+                v.public_send(method)
+              end
+            end
+          else
+            super()
+          end
+        end
+      end
+    end
+  end
+end
+
+ActiveRecord::ConnectionAdapters::ConnectionPool.send(:prepend, Octopus::ConnectionPool::QueryCacheForShards)

--- a/spec/octopus/query_cache_for_shards_spec.rb
+++ b/spec/octopus/query_cache_for_shards_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+unless Octopus.rails4?
+  describe Octopus::ConnectionPool::QueryCacheForShards do
+    subject(:query_cache_on_shard) { ActiveRecord::Base.using(:brazil).connection.query_cache_enabled }
+
+    context 'when query cache is enabled on the primary connection_pool' do
+      before { ActiveRecord::Base.connection_pool.enable_query_cache! }
+      it { is_expected.to be true }
+    end
+
+    context 'when query cache is disabled on the primary connection_pool' do
+      before { ActiveRecord::Base.connection_pool.disable_query_cache! }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
The `enable_query_cache!` and `disable_query_cache!` methods are moved to `ConnectionProxy` from `Connection` on Rails 5.
Currently Octopus only hijacks `Connection`'s methods to turn on/off the query cache for all shards, but it should hook `ConnectionProxy` on Rails5.

This fixes the issue that the query cache is shared beyond requests. Resolves #405.