### PR TITLE
Fix QueryCacheForShards breaking in environments where Octopus is not enabled

### DIFF
--- a/lib/octopus/query_cache_for_shards.rb
+++ b/lib/octopus/query_cache_for_shards.rb
@@ -4,10 +4,9 @@ module Octopus
     module QueryCacheForShards
       %i(enable_query_cache! disable_query_cache!).each do |method|
         define_method(method) do
-          shards = ActiveRecord::Base.connection.shards
-          if shards["master"] == self
+          if(Octopus.enabled? && (shards = ActiveRecord::Base.connection.shards)['master'] == self)
             shards.each do |shard_name, v|
-              if shard_name == "master"
+              if shard_name == 'master'
                 super()
               else
                 v.public_send(method)

--- a/spec/octopus/query_cache_for_shards_spec.rb
+++ b/spec/octopus/query_cache_for_shards_spec.rb
@@ -4,14 +4,37 @@ unless Octopus.rails4?
   describe Octopus::ConnectionPool::QueryCacheForShards do
     subject(:query_cache_on_shard) { ActiveRecord::Base.using(:brazil).connection.query_cache_enabled }
 
-    context 'when query cache is enabled on the primary connection_pool' do
-      before { ActiveRecord::Base.connection_pool.enable_query_cache! }
-      it { is_expected.to be true }
+    context 'Octopus enabled' do
+      context 'when query cache is enabled on the primary connection_pool' do
+        before { ActiveRecord::Base.connection_pool.enable_query_cache! }
+        it { is_expected.to be true }
+      end
+
+      context 'when query cache is disabled on the primary connection_pool' do
+        before { ActiveRecord::Base.connection_pool.disable_query_cache! }
+        it { is_expected.to be false }
+      end
     end
 
-    context 'when query cache is disabled on the primary connection_pool' do
-      before { ActiveRecord::Base.connection_pool.disable_query_cache! }
-      it { is_expected.to be false }
+    context 'Octopus disabled' do
+      before do
+        Rails = double
+        allow(Rails).to receive(:env).and_return('staging')
+      end
+
+      after do
+        Object.send(:remove_const, :Rails)
+      end
+
+      context 'when query cache is enabled on the primary connection_pool' do
+        before { ActiveRecord::Base.connection_pool.enable_query_cache! }
+        it { is_expected.to be true }
+      end
+
+      context 'when query cache is disabled on the primary connection_pool' do
+        before { ActiveRecord::Base.connection_pool.disable_query_cache! }
+        it { is_expected.to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
The new QueryCacheForShards fix for Rails 5 raises an exception when running in an environment Octopus is not enabled for.

The exception raised:
```
NoMethodError:
  undefined method `shards' for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter>
```
(or whatever adapter you are using)

You can remove the `Octopus.enabled?` check from my change and the tests I added will show the exception.