### PR TITLE
Expand mysql2 gem version to fix CI test failures

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 4.0.0', "< 5.2.0"
 
   s.add_development_dependency 'appraisal', '>= 0.3.8'
-  s.add_development_dependency 'mysql2', '>= 0.4', "< 0.5"
+  s.add_development_dependency 'mysql2', '>= 0.3.18', "< 0.5"
   s.add_development_dependency 'pg', '~> 0.18'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.0.0"
+gem "mysql2", "~> 0.3.10"
 
 gemspec :path => "../"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.1.0"
+gem 'mysql2', '~> 0.3.13'
 
 gemspec :path => "../"


### PR DESCRIPTION
Currently, some CI test patterns are failing. This is because by recent update of mysql2 gem version specification in the commit d87f599. The `mysql2` gem version specified in `ar-octopus.gemspec` is conflicting with `rails4.gemspec` / `rails41.gemspec` specification.

This fixes the issue by expanding the version specification range of `mysql2` gem, and specifying the gem version referred by each version of activerecord explicitly.