### PR TITLE
Bb/raise e

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 4.0.0', "< 5.2.0"
 
   s.add_development_dependency 'appraisal', '>= 0.3.8'
-  s.add_development_dependency 'mysql2', '>= 0.4', "< 0.5"
+  s.add_development_dependency 'mysql2', '>= 0.3.18', "< 0.5"
   s.add_development_dependency 'pg', '~> 0.18'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -45,7 +45,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -62,7 +62,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -80,7 +80,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -166,7 +166,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -267,7 +267,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -34,22 +34,55 @@ module Octopus
       :prepared_statements, :transaction_state, :create_table, to: :select_connection
 
     def execute(sql, name = nil)
-      conn = select_connection
-      clean_connection_proxy if should_clean_connection_proxy?('execute')
-      conn.execute(sql, name)
+      begin
+        retries ||= 0
+        conn = select_connection
+        clean_connection_proxy if should_clean_connection_proxy?('execute')
+        conn.execute(sql, name)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error execute: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
+      end
     end
 
     def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
-      conn = select_connection
-      clean_connection_proxy if should_clean_connection_proxy?('insert')
-      conn.insert(arel, name, pk, id_value, sequence_name, binds)
+      begin
+        retries ||= 0
+        conn = select_connection
+        clean_connection_proxy if should_clean_connection_proxy?('insert')
+        conn.insert(arel, name, pk, id_value, sequence_name, binds)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error insert: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
+      end
     end
 
     def update(arel, name = nil, binds = [])
-      conn = select_connection
-      # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
-      clean_connection_proxy if should_clean_connection_proxy?('insert')
-      conn.update(arel, name, binds)
+      begin
+        retries ||= 0
+        conn = select_connection
+        # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
+        clean_connection_proxy if should_clean_connection_proxy?('insert')
+        conn.update(arel, name, binds)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error update: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
+      end
     end
 
     def delete(*args, &block)
@@ -118,12 +151,23 @@ module Octopus
     end
 
     def transaction(options = {}, &block)
-      if !sharded && current_model_replicated?
-        run_queries_on_shard(Octopus.master_shard) do
+      begin
+        retries ||= 0
+        if !sharded && current_model_replicated?
+          run_queries_on_shard(Octopus.master_shard) do
+            select_connection.transaction(options, &block)
+          end
+        else
           select_connection.transaction(options, &block)
         end
-      else
-        select_connection.transaction(options, &block)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error transaction: #{e.message}"
+          select_connection.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
       end
     end
 
@@ -188,28 +232,43 @@ module Octopus
 
     protected
 
+    def connection_bad(error)
+      error.include? "PG::ConnectionBad"
+    end
+
     # @thiagopradi - This legacy method missing logic will be keep for a while for compatibility
     # and will be removed when Octopus 1.0 will be released.
     # We are planning to migrate to a much stable logic for the Proxy that doesn't require method missing.
     def legacy_method_missing_logic(method, *args, &block)
-      if should_clean_connection_proxy?(method)
-        conn = select_connection
-        clean_connection_proxy
-        conn.send(method, *args, &block)
-      elsif should_send_queries_to_shard_slave_group?(method)
-        send_queries_to_shard_slave_group(method, *args, &block)
-      elsif should_send_queries_to_slave_group?(method)
-        send_queries_to_slave_group(method, *args, &block)
-      elsif should_send_queries_to_replicated_databases?(method)
-        send_queries_to_selected_slave(method, *args, &block)
-      else
-        val = select_connection.send(method, *args, &block)
+      begin
+        retries ||= 0
+        if should_clean_connection_proxy?(method)
+          conn = select_connection
+          clean_connection_proxy
+          conn.send(method, *args, &block)
+        elsif should_send_queries_to_shard_slave_group?(method)
+          send_queries_to_shard_slave_group(method, *args, &block)
+        elsif should_send_queries_to_slave_group?(method)
+          send_queries_to_slave_group(method, *args, &block)
+        elsif should_send_queries_to_replicated_databases?(method)
+          send_queries_to_selected_slave(method, *args, &block)
+        else
+          val = select_connection.send(method, *args, &block)
 
-        if val.instance_of? ActiveRecord::Result
-          val.current_shard = shard_name
+          if val.instance_of? ActiveRecord::Result
+            val.current_shard = shard_name
+          end
+
+          val
         end
-
-        val
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error legacy_method_missing_logic: #{e.message}"
+          select_connection.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
       end
     end
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -33,25 +33,15 @@ module Octopus
       :release_advisory_lock, :prepare_binds_for_database, :cacheable_query, :column_name_for_operation,
       :prepared_statements, :transaction_state, :create_table, to: :select_connection
 
-# connection_pool.connection.verify!
-
     def execute(sql, name = nil)
       conn = select_connection
       clean_connection_proxy if should_clean_connection_proxy?('execute')
-      conn.execute(sql, name)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      conn.verify!
       conn.execute(sql, name)
     end
 
     def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
       conn = select_connection
       clean_connection_proxy if should_clean_connection_proxy?('insert')
-      conn.insert(arel, name, pk, id_value, sequence_name, binds)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      conn.verify!
       conn.insert(arel, name, pk, id_value, sequence_name, binds)
     end
 
@@ -60,33 +50,17 @@ module Octopus
       # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
       clean_connection_proxy if should_clean_connection_proxy?('insert')
       conn.update(arel, name, binds)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      conn.verify!
-      conn.update(arel, name, binds)
     end
 
     def delete(*args, &block)
-      legacy_method_missing_logic('delete', *args, &block)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      select_connection.verify!
       legacy_method_missing_logic('delete', *args, &block)
     end
 
     def select_all(*args, &block)
       legacy_method_missing_logic('select_all', *args, &block)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      select_connection.verify!
-      legacy_method_missing_logic('select_all', *args, &block)
     end
 
     def select_value(*args, &block)
-      legacy_method_missing_logic('select_value', *args, &block)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      select_connection.verify!
       legacy_method_missing_logic('select_value', *args, &block)
     end
 
@@ -154,10 +128,6 @@ module Octopus
     end
 
     def method_missing(method, *args, &block)
-      legacy_method_missing_logic(method, *args, &block)
-    rescue ActiveRecord::StatementInvalid => e
-      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
-      select_connection.verify!
       legacy_method_missing_logic(method, *args, &block)
     end
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -33,15 +33,25 @@ module Octopus
       :release_advisory_lock, :prepare_binds_for_database, :cacheable_query, :column_name_for_operation,
       :prepared_statements, :transaction_state, :create_table, to: :select_connection
 
+# connection_pool.connection.verify!
+
     def execute(sql, name = nil)
       conn = select_connection
       clean_connection_proxy if should_clean_connection_proxy?('execute')
+      conn.execute(sql, name)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      conn.verify!
       conn.execute(sql, name)
     end
 
     def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
       conn = select_connection
       clean_connection_proxy if should_clean_connection_proxy?('insert')
+      conn.insert(arel, name, pk, id_value, sequence_name, binds)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      conn.verify!
       conn.insert(arel, name, pk, id_value, sequence_name, binds)
     end
 
@@ -50,17 +60,33 @@ module Octopus
       # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
       clean_connection_proxy if should_clean_connection_proxy?('insert')
       conn.update(arel, name, binds)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      conn.verify!
+      conn.update(arel, name, binds)
     end
 
     def delete(*args, &block)
+      legacy_method_missing_logic('delete', *args, &block)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      select_connection.verify!
       legacy_method_missing_logic('delete', *args, &block)
     end
 
     def select_all(*args, &block)
       legacy_method_missing_logic('select_all', *args, &block)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      select_connection.verify!
+      legacy_method_missing_logic('select_all', *args, &block)
     end
 
     def select_value(*args, &block)
+      legacy_method_missing_logic('select_value', *args, &block)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      select_connection.verify!
       legacy_method_missing_logic('select_value', *args, &block)
     end
 
@@ -128,6 +154,10 @@ module Octopus
     end
 
     def method_missing(method, *args, &block)
+      legacy_method_missing_logic(method, *args, &block)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error "Octopus connection lost rescue: #{e.message}"
+      select_connection.verify!
       legacy_method_missing_logic(method, *args, &block)
     end
 

--- a/lib/octopus/query_cache_for_shards.rb
+++ b/lib/octopus/query_cache_for_shards.rb
@@ -4,10 +4,9 @@ module Octopus
     module QueryCacheForShards
       %i(enable_query_cache! disable_query_cache!).each do |method|
         define_method(method) do
-          shards = ActiveRecord::Base.connection.shards
-          if shards["master"] == self
+          if(Octopus.enabled? && (shards = ActiveRecord::Base.connection.shards)['master'] == self)
             shards.each do |shard_name, v|
-              if shard_name == "master"
+              if shard_name == 'master'
                 super()
               else
                 v.public_send(method)


### PR DESCRIPTION
https://github.com/brianbroderick/octopus/blob/master/lib/octopus/proxy.rb#L83

this wraps an exception in `RuntimeError`, we were expecting PG::UniqueViolation wrapped by ActiveRecord::RecordNotUnique errors. Is there any way you can just `raise e` to keep the original exception class?