### PR TITLE
Support lazy batches

### DIFF
--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -517,7 +517,7 @@ describe Octopus::Model do
         @user3 = User.using(:brazil).create!(:name => 'User3')
       end
 
-      it "#find_each should work" do
+      it "#find_each should work with a block" do
         result_array = []
 
         User.using(:brazil).where("name is not NULL").find_each do |user|
@@ -527,10 +527,50 @@ describe Octopus::Model do
         expect(result_array).to eq([@user1, @user2, @user3])
       end
 
-      it "#find_in_batches, should work" do
+      it "#find_each should work as an enumerator" do
+        result_array = []
+
+        User.using(:brazil).where("name is not NULL").find_each.each do |user|
+          result_array << user
+        end
+
+        expect(result_array).to eq([@user1, @user2, @user3])
+      end
+
+      it "#find_each should work as a lazy enumerator" do
+        result_array = []
+
+        User.using(:brazil).where("name is not NULL").find_each.lazy.each do |user|
+          result_array << user
+        end
+
+        expect(result_array).to eq([@user1, @user2, @user3])
+      end
+
+      it "#find_in_batches should work with a block" do
         result_array = []
 
         User.using(:brazil).where("name is not NULL").find_in_batches(batch_size: 1) do |user|
+          result_array << user
+        end
+
+        expect(result_array).to eq([[@user1], [@user2], [@user3]])
+      end
+
+      it "#find_in_batches should work as an enumerator" do
+        result_array = []
+
+        User.using(:brazil).where("name is not NULL").find_in_batches(batch_size: 1).each do |user|
+          result_array << user
+        end
+
+        expect(result_array).to eq([[@user1], [@user2], [@user3]])
+      end
+
+      it "#find_in_batches should work as a lazy enumerator" do
+        result_array = []
+
+        User.using(:brazil).where("name is not NULL").find_in_batches(batch_size: 1).lazy.each do |user|
           result_array << user
         end
 

--- a/spec/octopus/relation_proxy_spec.rb
+++ b/spec/octopus/relation_proxy_spec.rb
@@ -58,8 +58,16 @@ describe Octopus::RelationProxy do
       end
     end
 
-    it "can deliver methods in ActiveRecord::Batches correctly" do
+    it "can deliver methods in ActiveRecord::Batches correctly when given a block" do
       expect { @relation.find_each(&:inspect) }.not_to raise_error
+    end
+
+    it "can deliver methods in ActiveRecord::Batches correctly as an enumerator" do
+      expect { @relation.find_each.each(&:inspect) }.not_to raise_error
+    end
+
+    it "can deliver methods in ActiveRecord::Batches correctly as a lazy enumerator" do
+      expect { @relation.find_each.lazy.each(&:inspect) }.not_to raise_error
     end
 
     context 'under Rails 4' do


### PR DESCRIPTION
Currently, if a batch method like `find_each` or `find_in_batches` is called without a block `Octopus::RelationProxy` will send `method` wrapped in `run_on_shard` to the `ActiveRecord::Relation`, but since the queries are not executed immediately, execution flow will leave the block and the shard will be immediately restored. When the `Enumerator` is used later, the relation will execute queries on the `:master` shard.

Instead we can return a new `Enumerator` and iterate the results from within a `run_on_shard` at its iteration time.