### PR TITLE
bugfix: transaction should not reassign @klass variable

### DIFF
--- a/lib/octopus/scope_proxy.rb
+++ b/lib/octopus/scope_proxy.rb
@@ -28,7 +28,7 @@ module Octopus
 
     # Transaction Method send all queries to a specified shard.
     def transaction(options = {}, &block)
-      run_on_shard { @klass = klass.transaction(options, &block) }
+      run_on_shard { klass.transaction(options, &block) }
     end
 
     def connection


### PR DESCRIPTION
Currently, using a transaction reassigns the `@klass` variable to the return value of the transaction.  This is problematic when assigning the class to a variable for using in scopes.  For example:

```
scope = User.using(:shard_1)
scope.transaction do
  # transaction code
  123
end
puts scope # result is 123
```

With this fix, `scope` will stay as the `User` class.