### PR TITLE
Mantain current shard with enum method after where.not

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'sqlite3', '>= 1.3.4'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'pry-byebug'
 
   s.license = 'MIT'

--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -27,6 +27,7 @@ module Octopus
     # `find { ... }` etc. should run_on_shard, `find(id)` should be sent to relation
     ENUM_WITH_BLOCK_METHODS = [:find, :select, :none?, :any?, :one?, :many?, :sum]
     BATCH_METHODS = [:find_each, :find_in_batches, :in_batches]
+    WHERE_CHAIN_METHODS = [:not]
 
     def method_missing(method, *args, &block)
       if !block && BATCH_METHODS.include?(method)
@@ -39,6 +40,8 @@ module Octopus
         end
       elsif ENUM_METHODS.include?(method) || block && ENUM_WITH_BLOCK_METHODS.include?(method)
         run_on_shard { @ar_relation.to_a }.public_send(method, *args, &block)
+      elsif WHERE_CHAIN_METHODS.include?(method)
+        ::Octopus::ScopeProxy.new(@current_shard, run_on_shard { @ar_relation.public_send(method, *args) } )
       elsif block
         @ar_relation.public_send(method, *args, &block)
       else

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -532,6 +532,16 @@ describe Octopus::Model do
         expect(result_array).to eq([@user1, @user2, @user3])
       end
 
+      it "#find_each should work with a where.not(...)" do
+        result_array = []
+
+        User.using(:brazil).where.not(:name => 'User2').find_each do |user|
+          result_array << user
+        end
+
+        expect(result_array).to eq([@user1, @user3])
+      end
+
       it "#find_each should work as an enumerator" do
         result_array = []
 


### PR DESCRIPTION
This is a bug fix.
Currently,  Enum method after `where.not` can't maintain current shard. For example:
```
User.using(:brazil).where.not(:name => 'User2').find_each { }
```
`find_each` should use `brazil` shard. but now it uses default shard because of a bug.
Because `find_each` is executed with `Octopus::RelationProxy` as the `self`. But It should be executed with  `Octopus::ScopeProxy`  to maintain current shard.