### PR TITLE
gracefully handle attributes object not implementing delegate_hash

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -52,7 +52,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
         current_shard_value = coder['attributes']['current_shard'].value if coder['attributes']['current_shard'].present? && coder['attributes']['current_shard'].value.present?
 
         coder['attributes'].send(:attributes).send(:values).delete('current_shard')
-        coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard')
+        coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard') if coder['attributes'].send(:attributes).respond_to?(:delegate_hash)
 
         obj.current_shard = current_shard_value if current_shard_value.present?
         obj

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -52,7 +52,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
         current_shard_value = coder['attributes']['current_shard'].value if coder['attributes']['current_shard'].present? && coder['attributes']['current_shard'].value.present?
 
         coder['attributes'].send(:attributes).send(:values).delete('current_shard')
-        coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard') if coder['attributes'].send(:attributes).respond_to?(:delegate_hash)
+        coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard') rescue NoMethodError
 
         obj.current_shard = current_shard_value if current_shard_value.present?
         obj


### PR DESCRIPTION
In certain edge cases that I can't come up with a good minimal reproduction of, `coder['attributes']` can be a `Hash` object instead of an `ActiveRecord::LazyAttributeHash`. Since `Hash` does not implement `#delegate_hash`, this results in the following error bubbling up from psych:

```
     NoMethodError:
       undefined method `delegate_hash' for #<Hash:0x00005596e12b2e10>
       Did you mean?  DelegateClass
     # /usr/share/ruby/psych/visitors/to_ruby.rb:382:in `init_with'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:374:in `revive'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:208:in `visit_Psych_Nodes_Mapping'
     # /usr/share/ruby/psych/visitors/visitor.rb:16:in `visit'
     # /usr/share/ruby/psych/visitors/visitor.rb:6:in `accept'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:32:in `accept'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:336:in `each'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:336:in `each_slice'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:336:in `revive_hash'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
     # /usr/share/ruby/psych/visitors/visitor.rb:16:in `visit'
     # /usr/share/ruby/psych/visitors/visitor.rb:6:in `accept'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:32:in `accept'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:311:in `visit_Psych_Nodes_Document'
     # /usr/share/ruby/psych/visitors/visitor.rb:16:in `visit'
     # /usr/share/ruby/psych/visitors/visitor.rb:6:in `accept'
     # /usr/share/ruby/psych/visitors/to_ruby.rb:32:in `accept'
     # /usr/share/ruby/psych/nodes/node.rb:50:in `to_ruby'
     # /usr/share/ruby/psych.rb:264:in `load'
```