### PR TITLE
Rs/add rescue to reconnect

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -45,7 +45,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -62,7 +62,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -80,7 +80,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -166,7 +166,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -286,7 +286,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end


### PR DESCRIPTION
### Summary
PR for reference only **DO NOT MERGE**

This Octopus fork catches `ActiveRecord::StatementInvalid` but then raises `e.message`.  This causes us to lose the underlying error class and we bubble up a `RuntimeError` instead.  As a result when we fail to catch `ActiveRecord::StatementInvalid`.  

This update changes the behavior to `raise e` instead of `e.message` which will bubble up the expected error class.

Diff from `c015aac`: https://github.com/thiagopradi/octopus/commit/190a4cd2d0e1823911597252e41e0f9924759834

### Testing
- [ ] When a `ActiveRecord::StatementInvalid` is raised the error class should be `ActiveRecord::StatementInvalid` **not** `RuntimeError`
