### PR TITLE
fixing case where delegate_hash isn't available

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -45,14 +45,17 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
 
       def init_with(coder)
         obj = super
-
         return obj unless Octopus.enabled?
         return obj if obj.class.connection_proxy.current_model_replicated?
 
         current_shard_value = coder['attributes']['current_shard'].value if coder['attributes']['current_shard'].present? && coder['attributes']['current_shard'].value.present?
 
+
         coder['attributes'].send(:attributes).send(:values).delete('current_shard')
-        coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard')
+        begin
+          coder['attributes'].send(:attributes).send(:delegate_hash).delete('current_shard')
+        rescue NoMethodError => e
+        end
 
         obj.current_shard = current_shard_value if current_shard_value.present?
         obj


### PR DESCRIPTION
and this was raising an error.  sidekiq + delayed_mailer and yaml

we use sidekiq's action_mailer extensions to add a delay
https://github.com/mperham/sidekiq/blob/v5.2.7/lib/sidekiq/extensions/action_mailer.rb#L33

which serializes yaml and then restores it when worker starts with 
https://github.com/ruby/psych/blob/master/lib/psych/visitors/to_ruby.rb#L394
which hits your init_with and raises exception on some of the cleanup code.   

so this pull fixes that by rescuing. 

some inspection could also take place but the this seemed more risky.   