### PR TITLE
Update collection_association.rb to fix failure in setting up shards in rails 6.0

### DIFF
--- a/lib/octopus/collection_association.rb
+++ b/lib/octopus/collection_association.rb
@@ -1,7 +1,7 @@
 module Octopus
   module CollectionAssociation
     def self.included(base)
-      if Octopus.rails51? || Octopus.rails52?
+      if Octopus.rails51? || Octopus.rails52? || Octopus.atleast_rails52? 
         base.sharded_methods :reader, :writer, :ids_reader, :ids_writer, :create, :create!,
                              :build, :include?,
                              :load_target, :reload, :size, :select


### PR DESCRIPTION
fix failure to set up shards in rails 6.0 active records