### PR TITLE
Fix: Preventing Duplicate Migrations on the Same Shard

### DIFF
--- a/lib/octopus/migration.rb
+++ b/lib/octopus/migration.rb
@@ -99,7 +99,7 @@ module Octopus
       
       def run_with_octopus(&block)
         return run_without_octopus(&block) unless connection.is_a?(Octopus::Proxy)
-        shards = migrations.map(&:shards).flatten.map(&:to_s)
+        shards = migrations.map(&:shards).flatten.map(&:to_s).uniq
         connection.send_queries_to_multiple_shards(shards) do
           run_without_octopus(&block)
         end
@@ -109,7 +109,7 @@ module Octopus
 
       def migrate_with_octopus(&block)
         return migrate_without_octopus(&block) unless connection.is_a?(Octopus::Proxy)
-        shards = migrations.map(&:shards).flatten.map(&:to_s)
+        shards = migrations.map(&:shards).flatten.map(&:to_s).uniq
         connection.send_queries_to_multiple_shards(shards) do
           migrate_without_octopus(&block)
         end

--- a/lib/octopus/version.rb
+++ b/lib/octopus/version.rb
@@ -1,3 +1,3 @@
 module Octopus
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end


### PR DESCRIPTION
**Issue**
Currently, the migration process runs multiple times on a given shard due to how shards are fetched and processed. This occurs because the list of shards is obtained using the expression` migrations.map(&:shards).flatten.map(&:to_s)`, resulting in an array of shard names. As a consequence, if a shard has 'n' associated migrations, the migration process will be executed 'n' times on that shard.

**Proposed Solution**
To address this issue and ensure that migrations are not duplicated on the same shard, we can modify the process as follows:

Instead of directly flattening the `migrations.map(&:shards)` array, we get unique elements `migrations.map(&:shards).uniq`.

This approach guarantees that each shard will only appear once in the resulting array, preventing duplicate migrations on the same shard.

**Benefits**
Improves the efficiency of the migration process by preventing unnecessary repeated migrations on the same shard.